### PR TITLE
Add Pandoc formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ let &verbose            = 1 " also increases verbosity of the editor as a whole
     [`astyle`](http://astyle.sourceforge.net)
 - OCaml
   - [`ocp-indent`](http://www.typerex.org/ocp-indent.html)
+- Pandoc Markdown
+  - [`pandoc`][https://pandoc.org/MANUAL.html]
 - Pawn
   - [`uncrustify`](http://uncrustify.sourceforge.net)
 - Perl

--- a/autoload/neoformat/formatters/pandoc.vim
+++ b/autoload/neoformat/formatters/pandoc.vim
@@ -1,0 +1,16 @@
+function! neoformat#formatters#pandoc#enabled() abort
+   return ['pandoc']
+endfunction
+
+function! neoformat#formatters#pandoc#pandoc() abort
+   return {
+            \ 'exe': 'pandoc',
+            \ 'args': ['-f markdown+autolink_bare_uris',
+            \ '-t markdown+autolink_bare_uris',
+            \ '--atx-headers',
+            \ '%:p',
+            \ '|',
+            \ "sed -e 's/\\\[/[/g'", "-e 's/\\\]/]/g'",],
+            \ 'no_append': 1
+            \ }
+endfunction

--- a/doc/neoformat.txt
+++ b/doc/neoformat.txt
@@ -126,6 +126,8 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
     [astyle](http://astyle.sourceforge.net)
 - OCaml
   - [ocp-indent](http://www.typerex.org/ocp-indent.html)
+- Pandoc Markdown
+  - [pandoc][https://pandoc.org/MANUAL.html]
 - Pawn
   - [uncrustify](http://uncrustify.sourceforge.net)
 - Perl


### PR DESCRIPTION
We can use Pandoc to format Pandoc-flavored Markdown.

The extra flags handle bare URLs not being escaped correctly and
non-standard Markdown headers.

We pipe to `sed` to fix incorrect bracket escaping since Pandoc does not
support the check box feature of Github Markdown.