### PR TITLE
Add `abort` to autoload functions

### DIFF
--- a/.vintrc.yaml
+++ b/.vintrc.yaml
@@ -11,5 +11,3 @@ policies:
         enabled: false
     ProhibitEqualTildeOperator:
         enabled: false
-    ProhibitNoAbortFunction:
-        enabled: false

--- a/autoload/neoformat.vim
+++ b/autoload/neoformat.vim
@@ -1,4 +1,4 @@
-function! neoformat#Start(user_formatter)
+function! neoformat#Start(user_formatter) abort
     let s:current_formatter_index = 0
     call neoformat#Neoformat(a:user_formatter)
 endfunction
@@ -60,7 +60,7 @@ function! s:get_enabled_formatters(filetype) abort
     return []
 endfunction
 
-function! neoformat#CompleteFormatters(ArgLead, CmdLine, CursorPos)
+function! neoformat#CompleteFormatters(ArgLead, CmdLine, CursorPos) abort
     if a:ArgLead =~ '[^A-Za-z0-9]'
         return []
     endif
@@ -75,7 +75,7 @@ function! neoformat#NextNeoformat() abort
     return neoformat#Neoformat('')
 endfunction
 
-function! s:autoload_func_exists(func_name)
+function! s:autoload_func_exists(func_name) abort
     try
         call eval(a:func_name . '()')
     catch /^Vim\%((\a\+)\)\=:E117/
@@ -84,7 +84,7 @@ function! s:autoload_func_exists(func_name)
     return 1
 endfunction
 
-function! s:split_filetypes(filetype)
+function! s:split_filetypes(filetype) abort
     if a:filetype == ''
         return ''
     endif

--- a/autoload/neoformat/formatters/arduino.vim
+++ b/autoload/neoformat/formatters/arduino.vim
@@ -1,15 +1,15 @@
-function! neoformat#formatters#arduino#enabled()
+function! neoformat#formatters#arduino#enabled() abort
    return ['uncrustify', 'clangformat', 'astyle']
 endfunction
 
-function! neoformat#formatters#arduino#uncrustify()
+function! neoformat#formatters#arduino#uncrustify() abort
     return neoformat#formatters#cpp#uncrustify()
 endfunction
 
-function! neoformat#formatters#arduino#clangformat()
+function! neoformat#formatters#arduino#clangformat() abort
     return neoformat#formatters#c#clangformat()
 endfunction
 
-function! neoformat#formatters#arduino#astyle()
+function! neoformat#formatters#arduino#astyle() abort
     return neoformat#formatters#c#astyle()
 endfunction

--- a/autoload/neoformat/formatters/c.vim
+++ b/autoload/neoformat/formatters/c.vim
@@ -1,19 +1,19 @@
-function! neoformat#formatters#c#enabled()
+function! neoformat#formatters#c#enabled() abort
    return ['uncrustify', 'clangformat', 'astyle']
 endfunction
 
-function! neoformat#formatters#c#uncrustify()
+function! neoformat#formatters#c#uncrustify() abort
     return {
            \ 'exe': 'uncrustify',
            \ 'args': ['-q', '-l C', '-f']
            \ }
 endfunction
 
-function! neoformat#formatters#c#clangformat()
+function! neoformat#formatters#c#clangformat() abort
     return {'exe': 'clang-format'}
 endfunction
 
-function! neoformat#formatters#c#astyle()
+function! neoformat#formatters#c#astyle() abort
     return {
             \ 'exe': 'astyle',
             \ 'args': ['--mode=c'],

--- a/autoload/neoformat/formatters/cpp.vim
+++ b/autoload/neoformat/formatters/cpp.vim
@@ -1,19 +1,19 @@
-function! neoformat#formatters#cpp#enabled()
+function! neoformat#formatters#cpp#enabled() abort
    return ['uncrustify', 'clangformat', 'astyle']
 endfunction
 
-function! neoformat#formatters#cpp#uncrustify()
+function! neoformat#formatters#cpp#uncrustify() abort
     return {
            \ 'exe': 'uncrustify',
            \ 'args': ['-q', '-l CPP', '-f']
            \ }
 endfunction
 
-function! neoformat#formatters#cpp#clangformat()
+function! neoformat#formatters#cpp#clangformat() abort
     return neoformat#formatters#c#clangformat()
 endfunction
 
-function! neoformat#formatters#cpp#astyle()
+function! neoformat#formatters#cpp#astyle() abort
     return neoformat#formatters#c#astyle()
 endfunction
 

--- a/autoload/neoformat/formatters/crystal.vim
+++ b/autoload/neoformat/formatters/crystal.vim
@@ -1,8 +1,8 @@
-function! neoformat#formatters#crystal#enabled()
+function! neoformat#formatters#crystal#enabled() abort
     return ['crystalformat']
 endfunction
 
-function! neoformat#formatters#crystal#crystalformat()
+function! neoformat#formatters#crystal#crystalformat() abort
     return {
         \ 'exe': 'crystal',
         \ 'args': ['tool', 'format'],

--- a/autoload/neoformat/formatters/cs.vim
+++ b/autoload/neoformat/formatters/cs.vim
@@ -1,15 +1,15 @@
-function! neoformat#formatters#cs#enabled()
+function! neoformat#formatters#cs#enabled() abort
     return ['uncrustify', 'astyle']
 endfunction
 
-function! neoformat#formatters#cs#uncrustify()
+function! neoformat#formatters#cs#uncrustify() abort
     return {
         \ 'exe': 'uncrustify',
         \ 'args': ['-q', '-l CS', '-f']
         \ }
 endfunction
 
-function! neoformat#formatters#cs#astyle()
+function! neoformat#formatters#cs#astyle() abort
     return {
         \ 'exe': 'astyle',
         \ 'args': ['--mode=cs'],

--- a/autoload/neoformat/formatters/css.vim
+++ b/autoload/neoformat/formatters/css.vim
@@ -1,19 +1,19 @@
-function! neoformat#formatters#css#enabled()
+function! neoformat#formatters#css#enabled() abort
     return ['cssbeautify', 'prettydiff', 'stylefmt', 'csscomb']
 endfunction
 
-function! neoformat#formatters#css#cssbeautify()
+function! neoformat#formatters#css#cssbeautify() abort
     return { 'exe': 'css-beautify' }
 endfunction
 
-function! neoformat#formatters#css#csscomb()
+function! neoformat#formatters#css#csscomb() abort
     return {
             \ 'exe': 'csscomb',
             \ 'replace': 1
             \ }
 endfunction
 
-function! neoformat#formatters#css#prettydiff()
+function! neoformat#formatters#css#prettydiff() abort
     return {
             \ 'exe': 'prettydiff',
             \ 'args': ['mode:"beautify"',
@@ -25,7 +25,7 @@ function! neoformat#formatters#css#prettydiff()
             \ }
 endfunction
 
-function! neoformat#formatters#css#stylefmt()
+function! neoformat#formatters#css#stylefmt() abort
     return {
         \ 'exe': 'stylefmt',
         \ 'replace': 1

--- a/autoload/neoformat/formatters/csv.vim
+++ b/autoload/neoformat/formatters/csv.vim
@@ -1,8 +1,8 @@
-function! neoformat#formatters#csv#enabled()
+function! neoformat#formatters#csv#enabled() abort
    return ['prettydiff']
 endfunction
 
-function! neoformat#formatters#csv#prettydiff()
+function! neoformat#formatters#csv#prettydiff() abort
     return {
             \ 'exe': 'prettydiff',
             \ 'args': ['mode:"beautify"',

--- a/autoload/neoformat/formatters/d.vim
+++ b/autoload/neoformat/formatters/d.vim
@@ -1,14 +1,14 @@
-function! neoformat#formatters#d#enabled()
+function! neoformat#formatters#d#enabled() abort
     return ['uncrustify', 'dfmt']
 endfunction
 
-function! neoformat#formatters#d#dfmt()
+function! neoformat#formatters#d#dfmt() abort
     return {
         \ 'exe': 'dfmt'
         \ }
 endfunction
 
-function! neoformat#formatters#d#uncrustify()
+function! neoformat#formatters#d#uncrustify() abort
     return {
         \ 'exe': 'uncrustify',
         \ 'args': ['-q', '-l D', '-f']

--- a/autoload/neoformat/formatters/dart.vim
+++ b/autoload/neoformat/formatters/dart.vim
@@ -1,8 +1,8 @@
-function! neoformat#formatters#dart#enabled()
+function! neoformat#formatters#dart#enabled() abort
     return ['dartfmt']
 endfunction
 
-function! neoformat#formatters#dart#dartfmt()
+function! neoformat#formatters#dart#dartfmt() abort
     return {
         \ 'exe': 'dartfmt',
         \ }

--- a/autoload/neoformat/formatters/elm.vim
+++ b/autoload/neoformat/formatters/elm.vim
@@ -1,8 +1,8 @@
-function! neoformat#formatters#elm#enabled()
+function! neoformat#formatters#elm#enabled() abort
     return ['elmformat']
 endfunction
 
-function! neoformat#formatters#elm#elmformat()
+function! neoformat#formatters#elm#elmformat() abort
     return {
         \ 'exe': 'elm-format'
         \ }

--- a/autoload/neoformat/formatters/go.vim
+++ b/autoload/neoformat/formatters/go.vim
@@ -1,12 +1,12 @@
-function! neoformat#formatters#go#enabled()
+function! neoformat#formatters#go#enabled() abort
    return ['goimports', 'gofmt']
 endfunction
 
-function! neoformat#formatters#go#gofmt()
+function! neoformat#formatters#go#gofmt() abort
     return {'exe': 'gofmt'}
  endfunction
 
-function! neoformat#formatters#go#goimports()
+function! neoformat#formatters#go#goimports() abort
     return {'exe': 'goimports'}
 endfunction
 

--- a/autoload/neoformat/formatters/haskell.vim
+++ b/autoload/neoformat/formatters/haskell.vim
@@ -1,8 +1,8 @@
-function! neoformat#formatters#haskell#enabled()
+function! neoformat#formatters#haskell#enabled() abort
     return ['stylishhaskell']
 endfunction
 
-function! neoformat#formatters#haskell#stylishhaskell()
+function! neoformat#formatters#haskell#stylishhaskell() abort
     return {
         \ 'exe': 'stylish-haskell'
         \ }

--- a/autoload/neoformat/formatters/html.vim
+++ b/autoload/neoformat/formatters/html.vim
@@ -1,8 +1,8 @@
-function! neoformat#formatters#html#enabled()
+function! neoformat#formatters#html#enabled() abort
     return ['htmlbeautify', 'tidy', 'prettydiff']
 endfunction
 
-function! neoformat#formatters#html#tidy()
+function! neoformat#formatters#html#tidy() abort
     return {
         \ 'exe': 'tidy',
         \ 'args': ['-quiet',
@@ -14,11 +14,11 @@ function! neoformat#formatters#html#tidy()
         \ }
 endfunction
 
-function! neoformat#formatters#html#htmlbeautify()
+function! neoformat#formatters#html#htmlbeautify() abort
     return {'exe': 'html-beautify'}
 endfunction
 
-function! neoformat#formatters#html#prettydiff()
+function! neoformat#formatters#html#prettydiff() abort
     return {
         \ 'exe': 'prettydiff',
         \ 'args': ['mode:"beautify"',

--- a/autoload/neoformat/formatters/jade.vim
+++ b/autoload/neoformat/formatters/jade.vim
@@ -1,7 +1,7 @@
-function! neoformat#formatters#jade#enabled()
+function! neoformat#formatters#jade#enabled() abort
    return ['pugbeautifier']
 endfunction
 
-function! neoformat#formatters#jade#pugbeautifier()
+function! neoformat#formatters#jade#pugbeautifier() abort
     return neoformat#formatters#pug#pugbeautifier()
 endfunction

--- a/autoload/neoformat/formatters/java.vim
+++ b/autoload/neoformat/formatters/java.vim
@@ -1,8 +1,8 @@
-function! neoformat#formatters#java#enabled()
+function! neoformat#formatters#java#enabled() abort
    return ['uncrustify', 'astyle', 'clang-format']
 endfunction
 
-function! neoformat#formatters#java#uncrustify()
+function! neoformat#formatters#java#uncrustify() abort
      return {
             \ 'exe': 'uncrustify',
             \ 'args': ['-q', '-l JAVA', '-f']
@@ -10,7 +10,7 @@ function! neoformat#formatters#java#uncrustify()
 endfunction
 
 
-function! neoformat#formatters#java#astyle()
+function! neoformat#formatters#java#astyle() abort
     return {
             \ 'exe': 'astyle',
             \ 'args': ['--mode=java'],
@@ -19,7 +19,7 @@ function! neoformat#formatters#java#astyle()
 endfunction
 
 
-function! neoformat#formatters#java#clangformat()
+function! neoformat#formatters#java#clangformat() abort
     return {'exe': 'clang-format'}
 endfunction
 

--- a/autoload/neoformat/formatters/javascript.vim
+++ b/autoload/neoformat/formatters/javascript.vim
@@ -1,16 +1,16 @@
-function! neoformat#formatters#javascript#enabled()
+function! neoformat#formatters#javascript#enabled() abort
     return ['jsbeautify', 'prettydiff', 'clangformat', 'esformatter']
 endfunction
 
-function! neoformat#formatters#javascript#jsbeautify()
+function! neoformat#formatters#javascript#jsbeautify() abort
     return {'exe': 'js-beautify'}
 endfunction
 
-function! neoformat#formatters#javascript#clangformat()
+function! neoformat#formatters#javascript#clangformat() abort
     return {'exe': 'clang-format'}
 endfunction
 
-function! neoformat#formatters#javascript#prettydiff()
+function! neoformat#formatters#javascript#prettydiff() abort
     return {
         \ 'exe': 'prettydiff',
         \ 'args': ['mode:"beautify"',
@@ -22,7 +22,7 @@ function! neoformat#formatters#javascript#prettydiff()
         \ }
 endfunction
 
-function! neoformat#formatters#javascript#esformatter()
+function! neoformat#formatters#javascript#esformatter() abort
     return {
         \ 'exe': 'esformatter'
         \ }

--- a/autoload/neoformat/formatters/jinja.vim
+++ b/autoload/neoformat/formatters/jinja.vim
@@ -1,11 +1,11 @@
-function! neoformat#formatters#jinja#enabled()
+function! neoformat#formatters#jinja#enabled() abort
     return ['prettydiff', 'htmlbeautify']
 endfunction
 
-function! neoformat#formatters#jinja#htmlbeautify()
+function! neoformat#formatters#jinja#htmlbeautify() abort
     return neoformat#formatters#html#htmlbeautify()
 endfunction
 
-function! neoformat#formatters#jinja#prettydiff()
+function! neoformat#formatters#jinja#prettydiff() abort
     return neoformat#formatters#html#prettydiff()
 endfunction

--- a/autoload/neoformat/formatters/json.vim
+++ b/autoload/neoformat/formatters/json.vim
@@ -1,11 +1,11 @@
-function! neoformat#formatters#json#enabled()
+function! neoformat#formatters#json#enabled() abort
     return ['jsbeautify', 'prettydiff']
 endfunction
 
-function! neoformat#formatters#json#jsbeautify()
+function! neoformat#formatters#json#jsbeautify() abort
     return neoformat#javascript#jsbeautify()
 endfunction
 
-function! neoformat#formatters#json#prettydiff()
+function! neoformat#formatters#json#prettydiff() abort
     return neoformat#javascript#prettydiff()
 endfunction

--- a/autoload/neoformat/formatters/less.vim
+++ b/autoload/neoformat/formatters/less.vim
@@ -1,11 +1,11 @@
-function! neoformat#formatters#less#enabled()
+function! neoformat#formatters#less#enabled() abort
     return ['csscomb', 'prettydiff']
 endfunction
 
-function! neoformat#formatters#less#csscomb()
+function! neoformat#formatters#less#csscomb() abort
     return neoformat#formatters#css#csscomb()
 endfunction
 
-function! neoformat#formatters#less#prettydiff()
+function! neoformat#formatters#less#prettydiff() abort
     return neoformat#formatters#css#prettydiff()
 endfunction

--- a/autoload/neoformat/formatters/lua.vim
+++ b/autoload/neoformat/formatters/lua.vim
@@ -1,8 +1,8 @@
-function! neoformat#formatters#lua#enabled()
+function! neoformat#formatters#lua#enabled() abort
     return ['luaformatter']
 endfunction
 
-function! neoformat#formatters#lua#luaformatter()
+function! neoformat#formatters#lua#luaformatter() abort
     return {
         \ 'exe': 'luaformatter'
         \ }

--- a/autoload/neoformat/formatters/markdown.vim
+++ b/autoload/neoformat/formatters/markdown.vim
@@ -1,8 +1,8 @@
-function! neoformat#formatters#markdown#enabled()
+function! neoformat#formatters#markdown#enabled() abort
    return ['remark']
 endfunction
 
-function! neoformat#formatters#markdown#remark()
+function! neoformat#formatters#markdown#remark() abort
     return {
             \ 'exe': 'remark',
             \ 'args': ['--no-color', '--silent']

--- a/autoload/neoformat/formatters/objc.vim
+++ b/autoload/neoformat/formatters/objc.vim
@@ -1,19 +1,19 @@
-function! neoformat#formatters#objc#enabled()
+function! neoformat#formatters#objc#enabled() abort
     return ['uncrustify', 'clangformat', 'astyle']
 endfunction
 
-function! neoformat#formatters#objc#uncrustify()
+function! neoformat#formatters#objc#uncrustify() abort
     return {
         \ 'exe': 'uncrustify',
         \ 'args': ['-q', '-l OC+', '-f']
         \ }
 endfunction
 
-function! neoformat#formatters#objc#clangformat()
+function! neoformat#formatters#objc#clangformat() abort
     return neoformat#formatters#c#clangformat()
 endfunction
 
-function! neoformat#formatters#objc#astyle()
+function! neoformat#formatters#objc#astyle() abort
     return neoformat#formatters#c#astyle()
 endfunction
 

--- a/autoload/neoformat/formatters/ocaml.vim
+++ b/autoload/neoformat/formatters/ocaml.vim
@@ -1,8 +1,8 @@
-function! neoformat#formatters#ocaml#enabled()
+function! neoformat#formatters#ocaml#enabled() abort
     return ['ocpindent']
 endfunction
 
-function! neoformat#formatters#ocaml#ocpindent()
+function! neoformat#formatters#ocaml#ocpindent() abort
     return {
         \ 'exe': 'ocp-indent',
         \ }

--- a/autoload/neoformat/formatters/pawn.vim
+++ b/autoload/neoformat/formatters/pawn.vim
@@ -1,8 +1,8 @@
-function! neoformat#formatters#pawn#enabled()
+function! neoformat#formatters#pawn#enabled() abort
     return ['uncrustify']
 endfunction
 
-function! neoformat#formatters#pawn#uncrustify()
+function! neoformat#formatters#pawn#uncrustify() abort
     return {
         \ 'exe': 'uncrustify',
         \ 'args': ['-q', '-l PAWN', '-f']

--- a/autoload/neoformat/formatters/perl.vim
+++ b/autoload/neoformat/formatters/perl.vim
@@ -1,8 +1,8 @@
-function! neoformat#formatters#perl#enabled()
+function! neoformat#formatters#perl#enabled() abort
    return ['perltidy']
 endfunction
 
-function! neoformat#formatters#perl#perltidy()
+function! neoformat#formatters#perl#perltidy() abort
     return {
             \ 'exe': 'perltidy',
             \ 'args': ['--standard-output']

--- a/autoload/neoformat/formatters/php.vim
+++ b/autoload/neoformat/formatters/php.vim
@@ -1,8 +1,8 @@
-function! neoformat#formatters#php#enabled()
+function! neoformat#formatters#php#enabled() abort
     return ['phpbeautifier']
 endfunction
 
-function! neoformat#formatters#php#phpbeautifier()
+function! neoformat#formatters#php#phpbeautifier() abort
     return {
         \ 'exe': 'php_beautifier',
         \ }

--- a/autoload/neoformat/formatters/proto.vim
+++ b/autoload/neoformat/formatters/proto.vim
@@ -1,7 +1,7 @@
-function! neoformat#formatters#proto#enabled()
+function! neoformat#formatters#proto#enabled() abort
     return ['clangformat']
 endfunction
 
-function! neoformat#formatters#proto#clangformat()
+function! neoformat#formatters#proto#clangformat() abort
     return neoformat#formatters#c#clangformat()
 endfunction

--- a/autoload/neoformat/formatters/pug.vim
+++ b/autoload/neoformat/formatters/pug.vim
@@ -1,8 +1,8 @@
-function! neoformat#formatters#pug#enabled()
+function! neoformat#formatters#pug#enabled() abort
    return ['pugbeautifier']
 endfunction
 
-function! neoformat#formatters#pug#pugbeautifier()
+function! neoformat#formatters#pug#pugbeautifier() abort
     return {
         \ 'exe': 'pug-beautifier',
         \ 'args': ['-s 2']

--- a/autoload/neoformat/formatters/ruby.vim
+++ b/autoload/neoformat/formatters/ruby.vim
@@ -1,8 +1,8 @@
-function! neoformat#formatters#ruby#enabled()
+function! neoformat#formatters#ruby#enabled() abort
    return ['rubybeautify']
 endfunction
 
-function! neoformat#formatters#ruby#rubybeautify()
+function! neoformat#formatters#ruby#rubybeautify() abort
      return {
         \ 'exe': 'ruby-beautify',
         \ 'args': ['--spaces', '-c 2']

--- a/autoload/neoformat/formatters/rust.vim
+++ b/autoload/neoformat/formatters/rust.vim
@@ -1,8 +1,8 @@
-function! neoformat#formatters#rust#enabled()
+function! neoformat#formatters#rust#enabled() abort
     return ['rustfmt']
 endfunction
 
-function! neoformat#formatters#rust#rustfmt()
+function! neoformat#formatters#rust#rustfmt() abort
     return {
         \ 'exe': 'rustfmt',
         \ 'replace': 1

--- a/autoload/neoformat/formatters/sass.vim
+++ b/autoload/neoformat/formatters/sass.vim
@@ -1,15 +1,15 @@
-function! neoformat#formatters#sass#enabled()
+function! neoformat#formatters#sass#enabled() abort
    return ['sassconvert', 'csscomb']
 endfunction
 
-function! neoformat#formatters#sass#sassconvert()
+function! neoformat#formatters#sass#sassconvert() abort
     return {
             \ 'exe': 'sass-convert',
             \ 'args': ['-T sass']
             \ }
 endfunction
 
-function! neoformat#formatters#sass#csscomb()
+function! neoformat#formatters#sass#csscomb() abort
     return neoformat#formatters#css#csscomb()
 endfunction
 

--- a/autoload/neoformat/formatters/scala.vim
+++ b/autoload/neoformat/formatters/scala.vim
@@ -1,8 +1,8 @@
-function! neoformat#formatters#scala#enabled()
+function! neoformat#formatters#scala#enabled() abort
     return ['scalariform']
 endfunction
 
-function! neoformat#formatters#scala#scalariform()
+function! neoformat#formatters#scala#scalariform() abort
     return {
         \ 'exe': 'scalariform',
         \ 'args': ['--stdout']

--- a/autoload/neoformat/formatters/scss.vim
+++ b/autoload/neoformat/formatters/scss.vim
@@ -1,22 +1,22 @@
-function! neoformat#formatters#scss#enabled()
+function! neoformat#formatters#scss#enabled() abort
    return ['sassconvert', 'stylefmt', 'prettydiff', 'csscomb']
 endfunction
 
-function! neoformat#formatters#scss#sassconvert()
+function! neoformat#formatters#scss#sassconvert() abort
     return {
             \ 'exe': 'sass-convert',
             \ 'args': ['-T scss']
             \ }
 endfunction
 
-function! neoformat#formatters#scss#csscomb()
+function! neoformat#formatters#scss#csscomb() abort
     return neoformat#formatters#css#csscomb()
 endfunction
 
-function! neoformat#formatters#scss#prettydiff()
+function! neoformat#formatters#scss#prettydiff() abort
     return neoformat#formatters#css#prettydiff()
 endfunction
 
-function! neoformat#formatters#scss#stylefmt()
+function! neoformat#formatters#scss#stylefmt() abort
     return neoformat#formatters#css#stylefmt()
 endfunction

--- a/autoload/neoformat/formatters/sql.vim
+++ b/autoload/neoformat/formatters/sql.vim
@@ -1,8 +1,8 @@
-function! neoformat#formatters#sql#enabled()
+function! neoformat#formatters#sql#enabled() abort
     return ['sqlformat']
 endfunction
 
-function! neoformat#formatters#sql#sqlformat()
+function! neoformat#formatters#sql#sqlformat() abort
     return {
         \ 'exe': 'sqlformat',
         \ 'args': ['--reindent']

--- a/autoload/neoformat/formatters/typescript.vim
+++ b/autoload/neoformat/formatters/typescript.vim
@@ -1,8 +1,8 @@
-function! neoformat#formatters#typescript#enabled()
+function! neoformat#formatters#typescript#enabled() abort
    return ['tsfmt']
 endfunction
 
-function! neoformat#formatters#typescript#tsfmt()
+function! neoformat#formatters#typescript#tsfmt() abort
     return {
         \ 'exe': 'tsfmt'
         \ }

--- a/autoload/neoformat/formatters/vala.vim
+++ b/autoload/neoformat/formatters/vala.vim
@@ -1,10 +1,10 @@
-function! neoformat#formatters#vala#uncrustify()
+function! neoformat#formatters#vala#uncrustify() abort
     return {
         \ 'exe': 'uncrustify',
         \ 'args': ['-q', '-l VALA', '-f']
         \ }
 endfunction
 
-function! neoformat#formatters#vala#enabled()
+function! neoformat#formatters#vala#enabled() abort
     return ['uncrustify']
 endfunction

--- a/autoload/neoformat/formatters/xhtml.vim
+++ b/autoload/neoformat/formatters/xhtml.vim
@@ -1,8 +1,8 @@
-function! neoformat#formatters#xhtml#enabled()
+function! neoformat#formatters#xhtml#enabled() abort
    return ['tidy', 'prettydiff']
 endfunction
 
-function! neoformat#formatters#xhtml#tidy()
+function! neoformat#formatters#xhtml#tidy() abort
     return {
             \ 'exe': 'tidy',
             \ 'args': ['-quiet',
@@ -15,6 +15,6 @@ function! neoformat#formatters#xhtml#tidy()
             \ }
 endfunction
 
-function! neoformat#formatters#xhtml#prettydiff()
+function! neoformat#formatters#xhtml#prettydiff() abort
     return neoformat#formatters#html#prettydiff()
 endfunction

--- a/autoload/neoformat/formatters/xml.vim
+++ b/autoload/neoformat/formatters/xml.vim
@@ -1,8 +1,8 @@
-function! neoformat#formatters#xml#enabled()
+function! neoformat#formatters#xml#enabled() abort
    return ['tidy', 'prettydiff']
 endfunction
 
-function! neoformat#formatters#xml#tidy()
+function! neoformat#formatters#xml#tidy() abort
     return {
             \ 'exe': 'tidy',
             \ 'args': ['-quiet',
@@ -15,6 +15,6 @@ function! neoformat#formatters#xml#tidy()
             \ }
 endfunction
 
-function! neoformat#formatters#xml#prettydiff()
+function! neoformat#formatters#xml#prettydiff() abort
     return neoformat#formatters#html#prettydiff()
 endfunction

--- a/autoload/neoformat/run.vim
+++ b/autoload/neoformat/run.vim
@@ -1,6 +1,6 @@
 let s:jobs = {}
 
-function! s:job_id(job)
+function! s:job_id(job) abort
     " 8 is the type Job
     if type(a:job) == 8
         let i = job_getchannel(a:job)
@@ -43,7 +43,7 @@ function! s:on_stdout(job_id, data) abort
     call extend(job.stdout, a:data)
 endfunction
 
-function! s:on_stdout_vim(job, data)
+function! s:on_stdout_vim(job, data) abort
     let id = s:job_id(a:job)
 
     if !has_key(s:jobs, id)


### PR DESCRIPTION
[See Vint linting
policy()]https://github.com/Kuniwak/vint/wiki/Vint-linting-policy-summar
y)

*`abort` forces the function to halt when it encounters an error.*