### PR TITLE
fix(html,css,js,scss): user indent settings

### DIFF
--- a/autoload/neoformat/formatters/css.vim
+++ b/autoload/neoformat/formatters/css.vim
@@ -5,6 +5,7 @@ endfunction
 function! neoformat#formatters#css#cssbeautify() abort
     return {
             \ 'exe': 'css-beautify',
+            \ 'args': ['--indent-size ' .shiftwidth()],
             \ 'stdin': 1,
             \ }
 endfunction

--- a/autoload/neoformat/formatters/html.vim
+++ b/autoload/neoformat/formatters/html.vim
@@ -7,9 +7,10 @@ function! neoformat#formatters#html#tidy() abort
         \ 'exe': 'tidy',
         \ 'args': ['-quiet',
         \          '--indent auto',
-        \          '--indent-spaces 4',
+        \          '--indent-spaces ' . shiftwidth(),
         \          '--vertical-space yes',
-        \          '--tidy-mark no'
+        \          '--tidy-mark no',
+        \          '-wrap' .&textwidth
         \         ]
         \ }
 endfunction
@@ -17,6 +18,7 @@ endfunction
 function! neoformat#formatters#html#htmlbeautify() abort
     return {
             \ 'exe': 'html-beautify',
+            \ 'args': ['--indent-size ' .shiftwidth()],
             \ 'stdin': 1,
             \ }
 endfunction

--- a/autoload/neoformat/formatters/javascript.vim
+++ b/autoload/neoformat/formatters/javascript.vim
@@ -5,6 +5,7 @@ endfunction
 function! neoformat#formatters#javascript#jsbeautify() abort
     return {
             \ 'exe': 'js-beautify',
+            \ 'args': ['--indent-size ' .shiftwidth()],
             \ 'stdin': 1,
             \ }
 endfunction

--- a/autoload/neoformat/formatters/scss.vim
+++ b/autoload/neoformat/formatters/scss.vim
@@ -5,7 +5,7 @@ endfunction
 function! neoformat#formatters#scss#sassconvert() abort
     return {
             \ 'exe': 'sass-convert',
-            \ 'args': ['-F scss', '-T scss', '-s'],
+            \ 'args': ['-F scss', '-T scss', '--indent ' . (&expandtab ? shiftwidth() : 't')],
             \ 'stdin': 1,
             \ }
 endfunction


### PR DESCRIPTION
Hi! If the user had settings for `shiftwidth`, the formatter should respect this. 

I went and added it for html,css,scss, and js (what I use most of the time.

🍻 