### PR TITLE
fix(doc): remove duplicate tag

### DIFF
--- a/doc/neoformat.txt
+++ b/doc/neoformat.txt
@@ -33,7 +33,7 @@ Install with [vim-plug](https://github.com/junegunn/vim-plug)
 	Plug 'sbdchd/neoformat'
 <
 ==============================================================================
-USAGE						*neoformat-usage* *Neoformat*
+USAGE						*neoformat-usage*
 
 Format the current file using its filetype
 >
@@ -64,8 +64,8 @@ Options:
 | `no_append` | do not append the `path` of the file to the formatter command,
 	     used when the `path` is in the middle of a command | default: 0 |
 	     optional
-| `filter`    | a filter to send formatter data through e.g. `2>/dev/null` 
-	     (used when formatter doesn't send correct status codes) 
+| `filter`    | a filter to send formatter data through e.g. `2>/dev/null`
+	     (used when formatter doesn't send correct status codes)
 	     | default: '' | optional
 
 Example:


### PR DESCRIPTION
Dein.vim was complaining about duplicate tags in your doc file, so I removed the second `Neoformat` tag.

```
[dein] Error generating helptags:
[dein] Vim(helptags):E154: Duplicate tag "Neoformat" in file /Users/mhartington/.config/nvim/.cache/init.vim/.dein/doc/neoformat.txt
[dein] function dein#end[1]..dein#util#_end[39]..dein#recache_runtimepath[1]..dein#install#_recache_runtimepath[20]..<SNR>9_helptags, line 12
```