### PR TITLE
JavaScript: Configures prettier to use single quotes

### DIFF
--- a/autoload/neoformat/formatters/javascript.vim
+++ b/autoload/neoformat/formatters/javascript.vim
@@ -39,5 +39,6 @@ endfunction
 function! neoformat#formatters#javascript#prettier() abort
     return {
         \ 'exe': 'prettier',
+        \ 'args': ['--single-quote']
         \ }
 endfunction


### PR DESCRIPTION
I've had to change the formatter for `prettier` directly to achieve this. There doesn't seem to be a configuration file for `prettier`, or a way to globally configure it.

I think a better idea would be to set a variable like `let g:neoformat_javascript_args` in my neovim configuration, but I'm not sure how to do that.