### PR TITLE
Add g:neoformat_try_formatprg

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ Configure enabled formatters.
 let g:neoformat_enabled_python = ['autopep8', 'yapf']
 ```
 
+Have Neoformat use &formatprg as a formatter
+
+```viml
+let g:neoformat_try_formatprg = 1
+```
+
 Enable basic formatting when a filetype is not found. Disabled by default.
 
 ```viml

--- a/autoload/neoformat.vim
+++ b/autoload/neoformat.vim
@@ -44,6 +44,13 @@ function! s:neoformat(bang, user_input, start_line, end_line) abort
             let definition = g:neoformat_{filetype}_{formatter}
         elseif s:autoload_func_exists('neoformat#formatters#' . filetype . '#' . formatter)
             let definition =  neoformat#formatters#{filetype}#{formatter}()
+        elseif &formatprg != '' && split(&formatprg)[0] ==# formatter
+            let fmt_prg_def = split(&formatprg)
+            let definition = {
+                    \ 'exe': fmt_prg_def[0],
+                    \ 'args': fmt_prg_def[1:],
+                    \ 'stdin': 1,
+                    \ }
         else
             call neoformat#utils#log('definition not found for formatter: ' . formatter)
             if using_user_passed_formatter
@@ -69,8 +76,10 @@ function! s:neoformat(bang, user_input, start_line, end_line) abort
 
         call neoformat#utils#log(cmd.exe)
         if cmd.stdin
+            call neoformat#utils#log('using stdin')
             let stdout = systemlist(cmd.exe, stdin)
         else
+            call neoformat#utils#log('using tmp file')
             call mkdir('/tmp/neoformat', 'p')
             call writefile(stdin, cmd.tmp_file_path)
             let stdout = systemlist(cmd.exe)
@@ -108,12 +117,22 @@ function! s:neoformat(bang, user_input, start_line, end_line) abort
 endfunction
 
 function! s:get_enabled_formatters(filetype) abort
-    if exists('g:neoformat_enabled_' . a:filetype)
-        return g:neoformat_enabled_{a:filetype}
-    elseif s:autoload_func_exists('neoformat#formatters#' . a:filetype . '#enabled')
-        return neoformat#formatters#{a:filetype}#enabled()
+    if &formatprg != '' && get(g:, 'neoformat_try_formatprg', 0)
+        call neoformat#utils#log('using formatprg')
+        let format_prg_exe = [split(&formatprg)[0]]
+    else
+        let format_prg_exe = []
     endif
-    return []
+
+    " Note: we append format_prg_exe to ever return as it will either be
+    " [], or it will be a formatter that we want to try first
+
+    if exists('g:neoformat_enabled_' . a:filetype)
+        return format_prg_exe + g:neoformat_enabled_{a:filetype}
+    elseif s:autoload_func_exists('neoformat#formatters#' . a:filetype . '#enabled')
+        return format_prg_exe + neoformat#formatters#{a:filetype}#enabled()
+    endif
+    return format_prg_exe
 endfunction
 
 function! s:deletelines(start, end) abort
@@ -152,7 +171,7 @@ endfunction
 function! s:autoload_func_exists(func_name) abort
     try
         call eval(a:func_name . '()')
-    catch /^Vim\%((\a\+)\)\=:E117/
+    catch /^Vim\%((\a\+)\)\=:E/
         return 0
     endtry
     return 1

--- a/autoload/neoformat.vim
+++ b/autoload/neoformat.vim
@@ -45,6 +45,7 @@ function! s:neoformat(bang, user_input, start_line, end_line) abort
         elseif s:autoload_func_exists('neoformat#formatters#' . filetype . '#' . formatter)
             let definition =  neoformat#formatters#{filetype}#{formatter}()
         elseif &formatprg != '' && split(&formatprg)[0] ==# formatter
+                    \ && get(g:, 'neoformat_try_formatprg', 0)
             let fmt_prg_def = split(&formatprg)
             let definition = {
                     \ 'exe': fmt_prg_def[0],

--- a/doc/neoformat.txt
+++ b/doc/neoformat.txt
@@ -102,6 +102,10 @@ Define custom formatters.
 
     let g:neoformat_enabled_python = ['autopep8']
 <
+Have Neoformat use &formatprg as a formatter
+>
+    let g:neoformat_try_formatprg = 1
+<
 Enable basic formatting when a filetype is not found. Disabled by default.
 >
     " Enable alignment

--- a/test/after/cssbeautify-indent-6.css
+++ b/test/after/cssbeautify-indent-6.css
@@ -1,0 +1,3 @@
+.body {
+      color: red;
+}

--- a/test/autocomplete_test.vim
+++ b/test/autocomplete_test.vim
@@ -47,10 +47,10 @@ function! s:invalid_option()
     return [] == out
 endfunction
 
-function! s:multi_options()
-    let &filetype = 'python'
-    let g:neoformat_python_enabled = ['autopep8', 'yapf']
-    let out = neoformat#CompleteFormatters('autopep8', '', 0)
+function! s:formtprg_option()
+    let &filetype = 'javascript'
+    let &formatprg = 'testing'
+    let out = neoformat#CompleteFormatters('test', '', 0)
 
     return [] == out
 endfunction
@@ -58,6 +58,7 @@ endfunction
 " Run Tests
 call s:Run('s:valid_option')
 call s:Run('s:invalid_option')
+call s:Run('s:formtprg_option')
 
 
 " Check the outputs

--- a/test/test.py
+++ b/test/test.py
@@ -69,6 +69,43 @@ def test_visual_selection_with_filetype_and_formatter():
         assert before == after
 
 
+def test_formatprg_with_neoformat():
+    '''
+    Test that formatprg is processed by neoformat
+    '''
+
+    dir_before = 'before/'
+    filename = 'cssbeautify.css'
+    output_file = '/tmp/neoformat_fmt_prg_' + filename
+    viml = '''
+    let &formatprg = 'css-beautify -s 6 -n'
+    let g:neoformat_try_formatprg = 1
+    '''
+    cmd = f'nvim -u vimrc -c "set verbose=1 | {viml} | Neoformat | w! {output_file} | q! " --headless {dir_before + filename}'
+    run_cmd(cmd)
+    before = readlines(output_file)
+    after = readlines('./after/cssbeautify-indent-6.css')
+    assert before == after
+
+
+def test_formatprg_without_enable():
+    '''
+    Test that formatprg isn't use when not enabled
+    '''
+
+    dir_before = 'before/'
+    filename = 'cssbeautify.css'
+    output_file = '/tmp/neoformat_fmtprg_not_enabled' + filename
+    viml = '''
+    let &formatprg = 'css-beautify -s 6 -n'
+    '''
+    cmd = f'nvim -u vimrc -c "set verbose=1 | {viml} | Neoformat | w! {output_file} | q! " --headless {dir_before + filename}'
+    run_cmd(cmd)
+    before = readlines(output_file)
+    after = readlines('./after/cssbeautify.css')
+    assert before == after
+
+
 def test_vader():
     '''
     run *.vader tests


### PR DESCRIPTION
With `let g:neoformat_try_formatprg = 1`
Neoformat will try &formatprg before finding other formatter definitions

See https://github.com/sbdchd/neoformat/issues/36