### PR TITLE
restore stylish-haskell redirect to /dev/null

### DIFF
--- a/autoload/neoformat/formatters/haskell.vim
+++ b/autoload/neoformat/formatters/haskell.vim
@@ -13,6 +13,7 @@ endfunction
 function! neoformat#formatters#haskell#stylishhaskell() abort
     return {
         \ 'exe': 'stylish-haskell',
+        \ 'args': ['2>/dev/null'],
         \ 'stdin': 1,
         \ }
 endfunction


### PR DESCRIPTION
stylish-haskell doesn't seem to always handle errors correctly