### PR TITLE
Add rubocop formatter for ruby

### DIFF
--- a/autoload/neoformat/formatters/ruby.vim
+++ b/autoload/neoformat/formatters/ruby.vim
@@ -1,10 +1,18 @@
 function! neoformat#formatters#ruby#enabled() abort
-   return ['rubybeautify']
+   return ['rubybeautify', 'rubocop']
 endfunction
 
 function! neoformat#formatters#ruby#rubybeautify() abort
      return {
         \ 'exe': 'ruby-beautify',
         \ 'args': ['--spaces', '-c ' . shiftwidth()],
+        \ }
+endfunction
+
+function! neoformat#formatters#ruby#rubocop() abort
+     return {
+        \ 'exe': 'rubocop',
+        \ 'args': ['--auto-correct', '--stdin', '%:p', '2>/dev/null', '|', 'sed "1,/^====================$/d"'],
+        \ 'stdin': 1,
         \ }
 endfunction


### PR DESCRIPTION
This patch adds support for Rubocop for auto-correcting style problems. Rubocop is the de-facto standard for code styling and formatting in Ruby. 

Currently, Rubocop always prepends some metadata about the errors that we have to filter out with `sed` (see https://github.com/bbatsov/rubocop/issues/2502). In the future, there may be an option to allow us to avoid doing this.