### PR TITLE
Add latexindent formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,8 @@ endfunction
   - [`js-beautify`](https://github.com/beautify-web/js-beautify),
     [`prettydiff`](https://github.com/prettydiff/prettydiff)
     [`jq`](https://stedolan.github.io/jq/)
+- LaTeX
+  - [`latexindent`](https://github.com/cmhughes/latexindent.pl)
 - Less
   - [`csscomb`](http://csscomb.com),
     [`prettydiff`](https://github.com/prettydiff/prettydiff)

--- a/autoload/neoformat/formatters/tex.vim
+++ b/autoload/neoformat/formatters/tex.vim
@@ -1,0 +1,12 @@
+function! neoformat#formatters#tex#enabled() abort
+    return ['latexindent']
+endfunction
+
+function! neoformat#formatters#tex#latexindent() abort
+    return {
+        \ 'exe': 'latexindent',
+        \ 'args': ['-l', '-w'],
+        \ 'stdin': 0,
+        \ 'replace': 1
+        \ }
+endfunction

--- a/doc/neoformat.txt
+++ b/doc/neoformat.txt
@@ -218,6 +218,8 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
   - [`js-beautify`](https://github.com/beautify-web/js-beautify),
     [`prettydiff`](https://github.com/prettydiff/prettydiff)
     [`jq`](https://stedolan.github.io/jq/)
+- LaTeX
+  - [`latexindent`](https://github.com/cmhughes/latexindent.pl)
 - Less
   - [`csscomb`](http://csscomb.com),
     [`prettydiff`](https://github.com/prettydiff/prettydiff)


### PR DESCRIPTION
This patch adds a formatter for LaTeX. Unfortunately, when using the version latexindent bundled with TeX Live and a newer version of perl, it spits a handful of deprecation warnings out. I resolved this by manually calling the script from perl with the X flag. If there is a way to ignore stdout and only read the file, that would be better solution, however this works as-is.