### PR TITLE
remark: fix stdin issue

### DIFF
--- a/autoload/neoformat/formatters/markdown.vim
+++ b/autoload/neoformat/formatters/markdown.vim
@@ -5,7 +5,6 @@ endfunction
 function! neoformat#formatters#markdown#remark() abort
     return {
             \ 'exe': 'remark',
-            \ 'args': ['--no-color', '--silent'],
-            \ 'stdin': 1
+            \ 'args': ['--no-color', '--silent']
             \ }
 endfunction


### PR DESCRIPTION
`remark: 7.0.0` and `remark-cli: 3.0.0` doesn't support stdin method

```
Neoformat: ['<stdin>', '  1:1  error  TypeError: Path must be a string. Received undefined' ...
```

so use `/tmp/neoformat` instead.