### PR TITLE
Remove `mmd_title_block` from Pandoc formatter

### DIFF
--- a/autoload/neoformat/formatters/pandoc.vim
+++ b/autoload/neoformat/formatters/pandoc.vim
@@ -5,7 +5,7 @@ endfunction
 function! neoformat#formatters#pandoc#pandoc() abort
    return {
             \ 'exe': 'pandoc',
-            \ 'args': ['-f markdown+abbreviations+autolink_bare_uris+markdown_attribute+mmd_header_identifiers+mmd_link_attributes+mmd_title_block+tex_math_double_backslash+emoji',
+            \ 'args': ['-f markdown+abbreviations+autolink_bare_uris+markdown_attribute+mmd_header_identifiers+mmd_link_attributes+tex_math_double_backslash+emoji',
             \ '-t markdown+raw_tex-native_spans-simple_tables-multiline_tables+emoji',
             \ '--normalize',
             \ '-s',


### PR DESCRIPTION
This causes any lines with colons to be treated as title blocks, which
leads to some nasty shocks when formatting.