### PR TITLE
add eslint_d support

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,8 +217,9 @@ endfunction
     [`prettier`](https://github.com/jlongster/prettier),
     [`prettydiff`](https://github.com/prettydiff/prettydiff),
     [`clang-format`](http://clang.llvm.org/docs/ClangFormat.html),
-    [`esformatter`](https://github.com/millermedeiros/esformatter/)
-    [`prettier-eslint`](https://github.com/kentcdodds/prettier-eslint-cli)
+    [`esformatter`](https://github.com/millermedeiros/esformatter/),
+    [`prettier-eslint`](https://github.com/kentcdodds/prettier-eslint-cli),
+    [`eslint_d`](https://github.com/mantoni/eslint_d.js)
 - JSON
   - [`js-beautify`](https://github.com/beautify-web/js-beautify),
     [`prettydiff`](https://github.com/prettydiff/prettydiff)

--- a/autoload/neoformat/formatters/javascript.vim
+++ b/autoload/neoformat/formatters/javascript.vim
@@ -1,5 +1,5 @@
 function! neoformat#formatters#javascript#enabled() abort
-    return ['jsbeautify', 'prettier', 'prettydiff', 'clangformat', 'esformatter', 'prettiereslint']
+    return ['jsbeautify', 'prettier', 'prettydiff', 'clangformat', 'esformatter', 'prettiereslint', 'eslint_d']
 endfunction
 
 function! neoformat#formatters#javascript#jsbeautify() abort
@@ -48,6 +48,13 @@ function! neoformat#formatters#javascript#prettiereslint() abort
     return {
         \ 'exe': 'prettier-eslint',
         \ 'args': ['--stdin'],
+        \ 'stdin': 1,
+        \ }
+endfunction
+function! neoformat#formatters#javascript#eslint_d() abort
+    return {
+        \ 'exe': 'eslint_d',
+        \ 'args': ['--stdin','--fix-to-stdout'],
         \ 'stdin': 1,
         \ }
 endfunction

--- a/doc/neoformat.txt
+++ b/doc/neoformat.txt
@@ -212,8 +212,9 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
     [`prettier`](https://github.com/jlongster/prettier),
     [`prettydiff`](https://github.com/prettydiff/prettydiff),
     [`clang-format`](http://clang.llvm.org/docs/ClangFormat.html),
-    [`esformatter`](https://github.com/millermedeiros/esformatter/)
-    [`prettier-eslint`](https://github.com/kentcdodds/prettier-eslint-cli)
+    [`esformatter`](https://github.com/millermedeiros/esformatter/),
+    [`prettier-eslint`](https://github.com/kentcdodds/prettier-eslint-cli),
+    [`eslint_d`](https://github.com/mantoni/eslint_d.js)
 - JSON
   - [`js-beautify`](https://github.com/beautify-web/js-beautify),
     [`prettydiff`](https://github.com/prettydiff/prettydiff)


### PR DESCRIPTION
eslint_d is the only sane way to do autofixing on Vim with Eslint in terms of speed and battery usage.

Fixing https://github.com/mantoni/eslint_d.js/issues/64
