### PR TITLE
Check for existing tmp dir before creation

### DIFF
--- a/autoload/neoformat.vim
+++ b/autoload/neoformat.vim
@@ -82,7 +82,10 @@ function! s:neoformat(bang, user_input, start_line, end_line) abort
             let stdout = split(system(cmd.exe, stdin), '\n')
         else
             call neoformat#utils#log('using tmp file')
-            call mkdir('/tmp/neoformat', 'p')
+            let tmp_dir = '/tmp/neoformat'
+            if !isdirectory(tmp_dir)
+                call mkdir(tmp_dir, 'p')
+            endif
             call writefile(stdin, cmd.tmp_file_path)
             let stdout = split(system(cmd.exe), '\n')
         endif


### PR DESCRIPTION
Quick and dirty fix for #69. It seems that #66 will require more work for working cross platform on Windows machines - I don't have access to one, but this should ensure no errors on OSX and Linux.

I'm not familiar with testing for vim plugins, but am happy to add some if someone points me in the right direction.