### PR TITLE
Update css.vim: set indent size for prettydiff

### DIFF
--- a/autoload/neoformat/formatters/css.vim
+++ b/autoload/neoformat/formatters/css.vim
@@ -22,6 +22,7 @@ function! neoformat#formatters#css#prettydiff() abort
             \ 'exe': 'prettydiff',
             \ 'args': ['mode:"beautify"',
                      \ 'lang:"css"',
+                     \ 'insize:' .shiftwidth(),
                      \ 'readmethod:"filescreen"',
                      \ 'endquietly:"quiet"',
                      \ 'source:"%:p"'],

--- a/test/after/prettydiff.css
+++ b/test/after/prettydiff.css
@@ -1,4 +1,4 @@
 .body {
-    color: red;
+  color: red;
 }
 


### PR DESCRIPTION
This uses the commandline args to set the indentsize (that defaults to 4 spaces).