### PR TITLE
Add doc/tags to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 test/$VADER_OUTPUT_FILE
 node_modules/
 .cache
+doc/tags


### PR DESCRIPTION
Using git submodules for managing vim plugins, the automatic creation of this file leads to an always dirty submodule.