### PR TITLE
Fix a type mismatch error in better_echo

### DIFF
--- a/autoload/neoformat/utils.vim
+++ b/autoload/neoformat/utils.vim
@@ -19,9 +19,9 @@ function! neoformat#utils#msg(msg) abort
 endfunction
 
 function! s:better_echo(msg) abort
-    let msg = a:msg
     if type(a:msg) != type('')
-        let msg = string(a:msg)
+        echom 'Neoformat: ' . string(a:msg)
+    else
+        echom 'Neoformat: ' . a:msg
     endif
-    echom 'Neoformat: ' . msg
 endfunction


### PR DESCRIPTION
Dunno if this is different in neovim, but in vim 7.4 if you do
`:let foo = []`
`:let foo = ''`
You'll get the following error: 
`E706: Variable type mismatch for: foo`

This means that if you call `better_echo(['some string'])` it will fail with that error.