### PR TITLE
Add 'prettier' support for css, less and scss

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,8 @@ endfunction
   - [`latexindent`](https://github.com/cmhughes/latexindent.pl)
 - Less
   - [`csscomb`](http://csscomb.com),
-    [`prettydiff`](https://github.com/prettydiff/prettydiff)
+    [`prettydiff`](https://github.com/prettydiff/prettydiff),
+    [`prettier`](https://github.com/prettier/prettier)
 - Lua
   - [`luaformatter`](https://github.com/LuaDevelopmentTools/luaformatter)
 - Markdown

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ endfunction
 - Python
   - [`yapf`](https://github.com/google/yapf),
     [`autopep8`](https://github.com/hhatto/autopep8)
-  - [`isort](https://github.com/timothycrosley/isort)
+  - [`isort`](https://github.com/timothycrosley/isort)
 - Ruby
   - [`ruby-beautify`](https://github.com/erniebrodeur/ruby-beautify),
     [`rubocop`](https://github.com/bbatsov/rubocop)

--- a/README.md
+++ b/README.md
@@ -185,7 +185,8 @@ endfunction
   - `css-beautify` (ships with [`js-beautify`](https://github.com/beautify-web/js-beautify)),
     [`prettydiff`](https://github.com/prettydiff/prettydiff),
     [`stylefmt`](https://github.com/morishitter/stylefmt),
-    [`csscomb`](http://csscomb.com)
+    [`csscomb`](http://csscomb.com),
+    [`prettier`](https://github.com/prettier/prettier)
 - CSV
   - [`prettydiff`](https://github.com/prettydiff/prettydiff)
 - D

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ endfunction
     [`astyle`](http://astyle.sourceforge.net)
 - Javascript
   - [`js-beautify`](https://github.com/beautify-web/js-beautify),
-    [`prettier`](https://github.com/jlongster/prettier),
+    [`prettier`](https://github.com/prettier/prettier),
     [`prettydiff`](https://github.com/prettydiff/prettydiff),
     [`clang-format`](http://clang.llvm.org/docs/ClangFormat.html),
     [`esformatter`](https://github.com/millermedeiros/esformatter/),

--- a/README.md
+++ b/README.md
@@ -279,7 +279,8 @@ endfunction
 - SQL
   - `sqlformat` (ships with [sqlparse](https://github.com/andialbrecht/sqlparse))
 - Typescript
-  - [`tsfmt`](https://github.com/vvakame/typescript-formatter)
+  - [`tsfmt`](https://github.com/vvakame/typescript-formatter),
+    [`prettier`](https://github.com/prettier/prettier)
 - VALA
   - [`uncrustify`](http://uncrustify.sourceforge.net)
 - XHTML

--- a/README.md
+++ b/README.md
@@ -272,7 +272,8 @@ endfunction
   - [`sass-convert`](http://sass-lang.com/documentation/#executables),
     [`stylefmt`](https://github.com/morishitter/stylefmt),
     [`prettydiff`](https://github.com/prettydiff/prettydiff),
-    [`csscomb`](http://csscomb.com)
+    [`csscomb`](http://csscomb.com),
+    [`prettier`](https://github.com/prettier/prettier)
 - Shell
   - [`shfmt`](https://github.com/mvdan/sh)
 - SQL

--- a/autoload/neoformat/formatters/css.vim
+++ b/autoload/neoformat/formatters/css.vim
@@ -36,3 +36,11 @@ function! neoformat#formatters#css#stylefmt() abort
         \ 'stdin': 1,
         \ }
 endfunction
+
+function! neoformat#formatters#css#prettier() abort
+    return {
+        \ 'exe': 'prettier',
+        \ 'args': ['--stdin', '--parser', 'postcss'],
+        \ 'stdin': 1
+        \ }
+endfunction

--- a/autoload/neoformat/formatters/less.vim
+++ b/autoload/neoformat/formatters/less.vim
@@ -9,3 +9,7 @@ endfunction
 function! neoformat#formatters#less#prettydiff() abort
     return neoformat#formatters#css#prettydiff()
 endfunction
+
+function! neoformat#formatters#less#prettier() abort
+    return neoformat#formatters#css#prettier()
+endfunction

--- a/autoload/neoformat/formatters/scss.vim
+++ b/autoload/neoformat/formatters/scss.vim
@@ -21,3 +21,7 @@ endfunction
 function! neoformat#formatters#scss#stylefmt() abort
     return neoformat#formatters#css#stylefmt()
 endfunction
+
+function! neoformat#formatters#scss#prettier() abort
+    return neoformat#formatters#css#prettier()
+endfunction


### PR DESCRIPTION
The 1.4.0 release of prettier added support for css, less and scss: https://github.com/prettier/prettier/releases/tag/1.4.0

I also took the liberty to fix some minor issues in the README, hope you don't mind.