### PR TITLE
Add rufo ruby formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ endfunction
     [`autopep8`](https://github.com/hhatto/autopep8)
   - [`isort`](https://github.com/timothycrosley/isort)
 - Ruby
+  - [`rufo`](https://github.com/asterite/rufo),
   - [`ruby-beautify`](https://github.com/erniebrodeur/ruby-beautify),
     [`rubocop`](https://github.com/bbatsov/rubocop)
 - Rust

--- a/autoload/neoformat/formatters/ruby.vim
+++ b/autoload/neoformat/formatters/ruby.vim
@@ -1,5 +1,12 @@
 function! neoformat#formatters#ruby#enabled() abort
-   return ['rubybeautify', 'rubocop']
+   return ['rufo', 'rubybeautify', 'rubocop']
+endfunction
+
+function! neoformat#formatters#ruby#rufo() abort
+     return {
+        \ 'exe': 'rufo',
+        \ 'stdin': 1,
+        \ }
 endfunction
 
 function! neoformat#formatters#ruby#rubybeautify() abort

--- a/doc/neoformat.txt
+++ b/doc/neoformat.txt
@@ -258,6 +258,7 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
 - Ruby
   - [rufo](https://github.com/asterite/rufo)
   - [`ruby-beautify`](https://github.com/erniebrodeur/ruby-beautify)
+  - [`rubocop`](https://github.com/bbatsov/rubocop)
 - Rust
   - [`rustfmt`](https://github.com/rust-lang-nursery/rustfmt)
 - Sass

--- a/doc/neoformat.txt
+++ b/doc/neoformat.txt
@@ -256,6 +256,7 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
     [`autopep8`](https://github.com/hhatto/autopep8)
     [isort](https://github.com/timothycrosley/isort)
 - Ruby
+  - [rufo](https://github.com/asterite/rufo)
   - [`ruby-beautify`](https://github.com/erniebrodeur/ruby-beautify)
 - Rust
   - [`rustfmt`](https://github.com/rust-lang-nursery/rustfmt)


### PR DESCRIPTION
This enables `https://github.com/asterite/rufo` as a formatter for ruby. It's damn fast and awesome. Thanks @asterite. And thanks @sbdchd for neoformat :)