### PR TITLE
Add notes to docs about using `undojoin` to skip over formatting changes on undo

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,13 @@ Or perhaps run a formatter on save
 ```viml
 augroup fmt
   autocmd!
-  autocmd BufWritePre * Neoformat
+  autocmd BufWritePre * undojoin | Neoformat
 augroup END
 ```
+
+The `undojoin` command will put changes made by Neoformat into the same
+`undo-block` with the latest preceding change. See
+[Managing Undo History](#managing-undo-history).
 
 ## Install
 
@@ -168,6 +172,28 @@ function! neoformat#formatters#{{ filetype }}#{{ other formatter name }}() abort
   return {'exe': {{ other formatter name }}
 endfunction
 ```
+
+## Managing Undo History
+
+If you use an `autocmd` to run Neoformat on save, and you have your editor
+configured to save automatically on `CursorHold` then you might run into
+problems reverting changes. Pressing `u` will undo the last change made by
+Neoformat instead of the change that you made yourself - and then Neoformat
+will run again redoing the change that you just reverted. To avoid this
+problem you can run Neoformat with the Vim `undojoin` command to put changes
+made by Neoformat into the same `undo-block` with the preceding change. For
+example:
+
+```viml
+augroup fmt
+  autocmd!
+  autocmd BufWritePre * undojoin | Neoformat
+augroup END
+```
+
+When `undojoin` is used this way pressing `u` will "skip over" the Neoformat
+changes - it will revert both the changes made by Neoformat and the change
+that caused Neoformat to be invoked.
 
 ## Supported Filetypes
 

--- a/doc/neoformat.txt
+++ b/doc/neoformat.txt
@@ -3,8 +3,9 @@
 CONTENTS					*neoformat-contents*
 
 Introduction		|neoformat-introduction|
-Install			    |neoformat-install|
-Usage			    |neoformat-usage|
+Install			|neoformat-install|
+Usage			|neoformat-usage|
+Managing Undo History	|neoformat-managing-undo-history|
 Supported Filetypes	|neoformat-supported-filetypes|
 
 ==============================================================================
@@ -61,9 +62,13 @@ Or perhaps run a formatter on save
 >
     augroup fmt
       autocmd!
-      autocmd BufWritePre * Neoformat
+      autocmd BufWritePre * undojoin | Neoformat
     augroup END
 <
+
+The |undojoin| command will put changes made by Neoformat into the same
+|undo-block| with the latest preceding change. See
+|neoformat-managing-undo-history|.
 
 
 ==============================================================================
@@ -160,6 +165,29 @@ See Config above for options
       return {'exe': {{ other formatter name }}
     endfunction
 <
+
+==============================================================================
+MANAGING UNDO HISTORY			*neoformat-managing-undo-history*
+
+If you use an |autocmd| to run Neoformat on save, and you have your editor
+configured to save automatically on |CursorHold| then you might run into
+problems reverting changes. Pressing |u| will undo the last change made by
+Neoformat instead of the change that you made yourself - and then Neoformat
+will run again redoing the change that you just reverted. To avoid this
+problem you can run Neoformat with the Vim |undojoin| command to put changes
+made by Neoformat into the same |undo-block| with the preceding change. For
+example:
+
+>
+    augroup fmt
+      autocmd!
+      autocmd BufWritePre * undojoin | Neoformat
+    augroup END
+<
+
+When |undojoin| is used this way pressing |u| will "skip over" the Neoformat
+changes - it will revert both the changes made by Neoformat and the change
+that caused Neoformat to be invoked.
 
 ==============================================================================
 SUPPORTED FILETYPES				*neoformat-supported-filetypes*


### PR DESCRIPTION
I run Neoformat on save, and I save automatically on `CursorHold`. That means that I don't have to even think about formatting or saving. But the combination does load to a frustrating experience where I have to tap `u` quickly twice to undo any change that leads to a formatting change. I finally did enough research to learn about the `undo-blocks` feature in Vim / Neovim, which provides a perfect solution for my situation! I wanted to share what I learned with other Neoformat users.