### PR TITLE
Add `prettier` to the list of formatters for Less/SCSS

### DIFF
--- a/autoload/neoformat/formatters/css.vim
+++ b/autoload/neoformat/formatters/css.vim
@@ -1,5 +1,5 @@
 function! neoformat#formatters#css#enabled() abort
-    return ['cssbeautify', 'prettydiff', 'stylefmt', 'csscomb']
+    return ['stylefmt', 'prettier', 'cssbeautify', 'prettydiff', 'csscomb']
 endfunction
 
 function! neoformat#formatters#css#cssbeautify() abort

--- a/autoload/neoformat/formatters/less.vim
+++ b/autoload/neoformat/formatters/less.vim
@@ -1,5 +1,5 @@
 function! neoformat#formatters#less#enabled() abort
-    return ['csscomb', 'prettydiff']
+    return ['prettier', 'csscomb', 'prettydiff']
 endfunction
 
 function! neoformat#formatters#less#csscomb() abort

--- a/autoload/neoformat/formatters/scss.vim
+++ b/autoload/neoformat/formatters/scss.vim
@@ -1,5 +1,5 @@
 function! neoformat#formatters#scss#enabled() abort
-   return ['sassconvert', 'stylefmt', 'prettydiff', 'csscomb']
+   return ['sassconvert', 'stylefmt', 'prettier', 'prettydiff', 'csscomb']
 endfunction
 
 function! neoformat#formatters#scss#sassconvert() abort

--- a/doc/neoformat.txt
+++ b/doc/neoformat.txt
@@ -211,6 +211,7 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
   - `crystal tool format` (ships with [`crystal`](http://crystal-lang.org))
 - CSS
   - `css-beautify` (ships with [`js-beautify`](https://github.com/beautify-web/js-beautify)),
+    [`prettier`](https://github.com/prettier/prettier),
     [`prettydiff`](https://github.com/prettydiff/prettydiff),
     [`stylefmt`](https://github.com/morishitter/stylefmt),
     [`csscomb`](http://csscomb.com)
@@ -256,6 +257,7 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
   - [`latexindent`](https://github.com/cmhughes/latexindent.pl)
 - Less
   - [`csscomb`](http://csscomb.com),
+    [`prettier`](https://github.com/prettier/prettier),
     [`prettydiff`](https://github.com/prettydiff/prettydiff)
 - Lua
   - [`luaformatter`](https://github.com/LuaDevelopmentTools/luaformatter)
@@ -298,6 +300,7 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
 - SCSS
   - [`sass-convert`](http://sass-lang.com/documentation/#executables),
     [`stylefmt`](https://github.com/morishitter/stylefmt),
+    [`prettier`](https://github.com/prettier/prettier),
     [`prettydiff`](https://github.com/prettydiff/prettydiff),
     [`csscomb`](http://csscomb.com)
 - Shell


### PR DESCRIPTION
For Less and SCSS, the `prettier` formatters are already defined, but they are not in the list. I just added it.