### PR TITLE
Reason ML support

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,8 @@ that caused Neoformat to be invoked.
   - [`yapf`](https://github.com/google/yapf),
     [`autopep8`](https://github.com/hhatto/autopep8)
   - [`isort`](https://github.com/timothycrosley/isort)
+- Reason
+  - [`refmt`](https://github.com/facebook/reason)
 - Ruby
   - [`rufo`](https://github.com/asterite/rufo),
   - [`ruby-beautify`](https://github.com/erniebrodeur/ruby-beautify),

--- a/autoload/neoformat/formatters/elm.vim
+++ b/autoload/neoformat/formatters/elm.vim
@@ -9,5 +9,3 @@ function! neoformat#formatters#elm#elmformat() abort
         \ 'stdin': 1,
         \ }
 endfunction
-
-

--- a/autoload/neoformat/formatters/reason.vim
+++ b/autoload/neoformat/formatters/reason.vim
@@ -1,0 +1,10 @@
+function! neoformat#formatters#reason() abort
+    return ['refmt']
+endfunction
+
+function! neoformat#formatters#reason#refmt() abort
+    return {
+        \ 'exe': 'refmt',
+        \ 'stdin': 1,
+        \ }
+endfunction

--- a/doc/neoformat.txt
+++ b/doc/neoformat.txt
@@ -287,6 +287,8 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
   - [`yapf`](https://github.com/google/yapf),
     [`autopep8`](https://github.com/hhatto/autopep8)
     [isort](https://github.com/timothycrosley/isort)
+- Reason
+  - [`refmt`](https://github.com/facebook/reason)
 - Ruby
   - [rufo](https://github.com/asterite/rufo)
   - [`ruby-beautify`](https://github.com/erniebrodeur/ruby-beautify)


### PR DESCRIPTION
Reason is a OCaml based language from Facebook. It comes with a
formatter called `refmt`, which all all Reason code is expected to be
formatted with. This adds support for this formatter.