### PR TITLE
Do not print error description at the top of file

### DIFF
--- a/autoload/neoformat/formatters/perl.vim
+++ b/autoload/neoformat/formatters/perl.vim
@@ -5,6 +5,7 @@ endfunction
 function! neoformat#formatters#perl#perltidy() abort
     return {
             \ 'exe': 'perltidy',
+            \ 'args': ['-q'],
             \ 'stdin': 1,
             \ }
 endfunction


### PR DESCRIPTION
This prevents an error message being printed to standard error when `perltidy` has a problem parsing the file. Without this, you end up with the error message at the top of your source code.

Currently, neoformat cannot tell that `perltidy` had an error as the exit code is 0 on error.  Related #94.