### PR TITLE
Add prettier formatter for GraphQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,8 @@ that caused Neoformat to be invoked.
 - Go
   - [`gofmt`](https://golang.org/cmd/gofmt/),
     [`goimports`](https://godoc.org/golang.org/x/tools/cmd/goimports)
+- GraphQL
+  - [`prettier`](https://github.com/prettier/prettier)
 - Haskell
   - [`stylish-haskell`](https://github.com/jaspervdj/stylish-haskell)
   - [`hindent`](https://github.com/chrisdone/hindent)

--- a/autoload/neoformat/formatters/graphql.vim
+++ b/autoload/neoformat/formatters/graphql.vim
@@ -1,0 +1,11 @@
+function! neoformat#formatters#graphql#enabled() abort
+    return ['prettier']
+endfunction
+
+function! neoformat#formatters#graphql#prettier() abort
+    return {
+        \ 'exe': 'prettier',
+        \ 'args': ['--stdin', '--parser', 'graphql'],
+        \ 'stdin': 1
+        \ }
+endfunction

--- a/doc/neoformat.txt
+++ b/doc/neoformat.txt
@@ -229,6 +229,8 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
 - Go
   - [`gofmt`](https://golang.org/cmd/gofmt/),
     [`goimports`](https://godoc.org/golang.org/x/tools/cmd/goimports)
+- GraphQL
+  - [`prettier`](https://github.com/prettier/prettier)
 - Haskell
   - [`stylish-haskell`](https://github.com/jaspervdj/stylish-haskell)
   - [`hindent`](https://github.com/chrisdone/hindent)


### PR DESCRIPTION
Prettier supports GraphQL parsing now, so we can use it to format graphql filetypes.