### PR TITLE
Define filepath for prettier and prettiereslint (#112)

### DIFF
--- a/autoload/neoformat/formatters/javascript.vim
+++ b/autoload/neoformat/formatters/javascript.vim
@@ -39,7 +39,7 @@ endfunction
 function! neoformat#formatters#javascript#prettier() abort
     return {
         \ 'exe': 'prettier',
-        \ 'args': ['--stdin'],
+        \ 'args': ['--stdin', '--stdin-filepath', '%:p'],
         \ 'stdin': 1,
         \ }
 endfunction
@@ -47,7 +47,7 @@ endfunction
 function! neoformat#formatters#javascript#prettiereslint() abort
     return {
         \ 'exe': 'prettier-eslint',
-        \ 'args': ['--stdin'],
+        \ 'args': ['--stdin', '--stdin-filepath', '%:p'],
         \ 'stdin': 1,
         \ }
 endfunction


### PR DESCRIPTION
`prettier` and `prettier-eslint` both look for configuration files relative to the formated file path (a Prettier configuration for both, and a ESLint configuration for `prettier-eslint`).

Using the `--stdin-filepath` option will make both commands using the expected configuration files instead of the ones relative to the current directory.