### PR TITLE
Update prettier options for CSS formatting

### DIFF
--- a/autoload/neoformat/formatters/css.vim
+++ b/autoload/neoformat/formatters/css.vim
@@ -40,7 +40,7 @@ endfunction
 function! neoformat#formatters#css#prettier() abort
     return {
         \ 'exe': 'prettier',
-        \ 'args': ['--stdin', '--parser', 'postcss'],
+        \ 'args': ['--stdin', '--parser', 'css'],
         \ 'stdin': 1
         \ }
 endfunction


### PR DESCRIPTION
This avoids the following warning when using prettier `>=1.7.0`

```
`--parser` with value `postcss` is deprecated. Prettier now treats it as: `--parser=css`.
```