### PR TITLE
Add `mix format` formatter for Elixir

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,8 @@ that caused Neoformat to be invoked.
     [`dfmt`](https://github.com/Hackerpilot/dfmt)
 - Dart
   - [`dartfmt`](https://www.dartlang.org/tools/)
+- Elixir
+  - [`mix format`](https://hexdocs.pm/mix/master/Mix.Tasks.Format.html)
 - Elm
   - [`elm-format`](https://github.com/avh4/elm-format)
 - Fish

--- a/autoload/neoformat/formatters/elixir.vim
+++ b/autoload/neoformat/formatters/elixir.vim
@@ -1,0 +1,11 @@
+function! neoformat#formatters#elixir#enabled() abort
+    return ['mixformat']
+endfunction
+
+function! neoformat#formatters#elixir#mixformat() abort
+    return {
+        \ 'exe': 'mix',
+        \ 'args': ['format', "-"],
+        \ 'stdin': 1
+        \ }
+endfunction

--- a/doc/neoformat.txt
+++ b/doc/neoformat.txt
@@ -222,6 +222,8 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
     [`dfmt`](https://github.com/Hackerpilot/dfmt)
 - Dart
   - [`dartfmt`](https://www.dartlang.org/tools/)
+- Elixir
+  - [mix format](https://hexdocs.pm/mix/master/Mix.Tasks.Format.html)
 - Elm
   - [`elm-format`](https://github.com/avh4/elm-format)
 - Fish


### PR DESCRIPTION
This PR proposes adding the new official Elixir code formatter, that will be part of the upcoming release (it is already available in `master` builds).

Tested with `mix format` on `master` Elixir.