### PR TITLE
Add built-in support for fixjson

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,8 @@ that caused Neoformat to be invoked.
   - [`js-beautify`](https://github.com/beautify-web/js-beautify),
     [`prettydiff`](https://github.com/prettydiff/prettydiff),
     [`prettier`](https://github.com/prettier/prettier),
-    [`jq`](https://stedolan.github.io/jq/)
+    [`jq`](https://stedolan.github.io/jq/),
+    [`fixjson`](https://github.com/rhysd/fixjson)
 - Kotlin
   - [`ktlint`](https://github.com/shyiko/ktlint)
 - LaTeX

--- a/autoload/neoformat/formatters/json.vim
+++ b/autoload/neoformat/formatters/json.vim
@@ -24,3 +24,12 @@ function! neoformat#formatters#json#prettier() abort
         \ 'stdin': 1,
         \ }
 endfunction
+
+function! neoformat#formatters#json#fixjson() abort
+    let l:filename = fnamemodify(bufname('%'), ':t')
+    return {
+        \ 'exe': 'fixjson',
+        \ 'args': ['--stdin-filename', l:filename],
+        \ 'stdin': 1,
+        \ }
+endfunction

--- a/doc/neoformat.txt
+++ b/doc/neoformat.txt
@@ -261,7 +261,8 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
   - [`js-beautify`](https://github.com/beautify-web/js-beautify),
     [`prettydiff`](https://github.com/prettydiff/prettydiff),
     [`prettier`](https://github.com/prettier/prettier),
-    [`jq`](https://stedolan.github.io/jq/)
+    [`jq`](https://stedolan.github.io/jq/),
+    [`fixjson`](https://github.com/rhysd/fixjson)
 - Kotlin
   - [`ktlint`](https://github.com/shyiko/ktlint)
 - LaTeX


### PR DESCRIPTION
[fixjson](https://github.com/rhysd/fixjson) is a JSON file fixer/formatter for humans using (relaxed) JSON5. It formats a JSON code and fixes some trivial errors at the same time.

I added a configuration of neoformat for fixjson.