### PR TITLE
Allow exit code 3 from rufo

### DIFF
--- a/autoload/neoformat/formatters/ruby.vim
+++ b/autoload/neoformat/formatters/ruby.vim
@@ -6,6 +6,7 @@ function! neoformat#formatters#ruby#rufo() abort
      return {
         \ 'exe': 'rufo',
         \ 'stdin': 1,
+        \ 'valid_exit_codes': [0, 3]
         \ }
 endfunction
 


### PR DESCRIPTION
Rufo exits with code `3` on a successfull change. See https://github.com/ruby-formatter/rufo#exit-codes. This change configures neoformat to allow that exitcode.