### PR TITLE
ocamlformat: obey .ocamlformat configuration

### DIFF
--- a/autoload/neoformat/formatters/ocaml.vim
+++ b/autoload/neoformat/formatters/ocaml.vim
@@ -11,7 +11,6 @@ endfunction
 function! neoformat#formatters#ocaml#ocamlformat() abort
     return {
         \ 'exe': 'ocamlformat',
-        \ 'args': ['--inplace'],
-        \ 'replace': 1,
+        \ 'args': ['--name', '%:p']
         \ }
 endfunction


### PR DESCRIPTION
ocamlformat reads optional configuration from a .ocamlformat file in the source tree.
But Neoformat called ocamlformat with a temporary file path in /tmp, so it never found those configuration files.

Tell ocamlformat the real path of the file so it can load its configuration.