### PR TITLE
Drop default line length for hindent

### DIFF
--- a/autoload/neoformat/formatters/haskell.vim
+++ b/autoload/neoformat/formatters/haskell.vim
@@ -5,7 +5,7 @@ endfunction
 function! neoformat#formatters#haskell#hindent() abort
     return {
         \ 'exe' : 'hindent',
-        \ 'args': ['--indent-size ' . shiftwidth(), '--line-length 80'],
+        \ 'args': ['--indent-size ' . shiftwidth()],
         \ 'stdin' : 1,
         \ }
 endfunction


### PR DESCRIPTION
Project specific configuration had been overwritten by this args. Also, hindent has default line length and it's 80(see https://github.com/commercialhaskell/hindent#customization).