### PR TITLE
Add another SQL option: pg_format from pgFormatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ that caused Neoformat to be invoked.
   - [`shfmt`](https://github.com/mvdan/sh)
 - SQL
   - `sqlformat` (ships with [sqlparse](https://github.com/andialbrecht/sqlparse))
+  - `pg_format` (ships with [pgFormatter](https://github.com/darold/pgFormatter))
 - Terraform
   - [`terraform`](https://www.terraform.io/docs/commands/fmt.html),
 - Typescript

--- a/autoload/neoformat/formatters/sql.vim
+++ b/autoload/neoformat/formatters/sql.vim
@@ -13,7 +13,7 @@ endfunction
 function! neoformat#formatters#sql#pg_format() abort
     return {
         \ 'exe': 'pg_format',
-        \ 'args': ['--reindent', '-'],
+        \ 'args': ['-'],
         \ 'stdin': 1,
         \ }
 endfunction

--- a/autoload/neoformat/formatters/sql.vim
+++ b/autoload/neoformat/formatters/sql.vim
@@ -1,10 +1,18 @@
 function! neoformat#formatters#sql#enabled() abort
-    return ['sqlformat']
+    return ['sqlformat', 'pg_format']
 endfunction
 
 function! neoformat#formatters#sql#sqlformat() abort
     return {
         \ 'exe': 'sqlformat',
+        \ 'args': ['--reindent', '-'],
+        \ 'stdin': 1,
+        \ }
+endfunction
+
+function! neoformat#formatters#sql#pg_format() abort
+    return {
+        \ 'exe': 'pg_format',
         \ 'args': ['--reindent', '-'],
         \ 'stdin': 1,
         \ }

--- a/doc/neoformat.txt
+++ b/doc/neoformat.txt
@@ -330,6 +330,7 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
   - [`shfmt`](https://github.com/mvdan/sh)
 - SQL
   - `sqlformat` (ships with [sqlparse](https://github.com/andialbrecht/sqlparse))
+  - `pg_format` (ships with [pgFormatter](https://github.com/darold/pgFormatter))
 - Terraform
   - [`terraform`](https://www.terraform.io/docs/commands/fmt.html)
 - Typescript


### PR DESCRIPTION
`sqlformat` from sqlparse [has issues](https://github.com/andialbrecht/sqlparse/issues/360#issuecomment-379706669) with reindenting SQL files containing `create table` statements.

`pg_format` from [pgFormatter](https://github.com/darold/pgFormatter) appears to do better, at least for this case.