### PR TITLE
Make sure `--stdin-filepath` is always provided for prettier

### DIFF
--- a/autoload/neoformat/formatters/css.vim
+++ b/autoload/neoformat/formatters/css.vim
@@ -40,7 +40,7 @@ endfunction
 function! neoformat#formatters#css#prettier() abort
     return {
         \ 'exe': 'prettier',
-        \ 'args': ['--stdin', '--parser', 'css'],
+        \ 'args': ['--stdin', '--stdin-filepath', '%:p', '--parser', 'css'],
         \ 'stdin': 1
         \ }
 endfunction

--- a/autoload/neoformat/formatters/graphql.vim
+++ b/autoload/neoformat/formatters/graphql.vim
@@ -5,7 +5,7 @@ endfunction
 function! neoformat#formatters#graphql#prettier() abort
     return {
         \ 'exe': 'prettier',
-        \ 'args': ['--stdin', '--parser', 'graphql'],
+        \ 'args': ['--stdin', '--stdin-filepath', '%:p', '--parser', 'graphql'],
         \ 'stdin': 1
         \ }
 endfunction

--- a/autoload/neoformat/formatters/json.vim
+++ b/autoload/neoformat/formatters/json.vim
@@ -20,7 +20,7 @@ endfunction
 function! neoformat#formatters#json#prettier() abort
     return {
         \ 'exe': 'prettier',
-        \ 'args': ['--stdin', '--parser', 'json'],
+        \ 'args': ['--stdin', '--stdin-filepath', '%:p', '--parser', 'json'],
         \ 'stdin': 1,
         \ }
 endfunction

--- a/autoload/neoformat/formatters/typescript.vim
+++ b/autoload/neoformat/formatters/typescript.vim
@@ -13,7 +13,7 @@ endfunction
 function! neoformat#formatters#typescript#prettier() abort
     return {
         \ 'exe': 'prettier',
-        \ 'args': ['--stdin', '--parser', 'typescript'],
+        \ 'args': ['--stdin', '--stdin-filepath', '%:p', '--parser', 'typescript'],
         \ 'stdin': 1
         \ }
 endfunction

--- a/autoload/neoformat/formatters/vue.vim
+++ b/autoload/neoformat/formatters/vue.vim
@@ -5,7 +5,7 @@ endfunction
 function! neoformat#formatters#vue#prettier() abort
     return {
         \ 'exe': 'prettier',
-        \ 'args': ['--stdin', '--parser', 'vue'],
+        \ 'args': ['--stdin', '--stdin-filepath', '%:p', '--parser', 'vue'],
         \ 'stdin': 1
         \ }
 endfunction


### PR DESCRIPTION
When using `prettier` with `--stdin`, it is _always_ needed to also pass `--stdin-filepath`, or it will not be able to figure out custom settings like EditorConfig.

This was done for javascript in earlier PR https://github.com/sbdchd/neoformat/pull/119, but this has to be done for every single file type.

References: https://github.com/prettier/prettier/issues/4351, https://github.com/sbdchd/neoformat/issues/105#issuecomment-383250126