### PR TITLE
Make json formatters list match the README

### DIFF
--- a/autoload/neoformat/formatters/json.vim
+++ b/autoload/neoformat/formatters/json.vim
@@ -1,5 +1,5 @@
 function! neoformat#formatters#json#enabled() abort
-    return ['jsbeautify', 'prettydiff', 'jq', 'prettier']
+    return ['jsbeautify', 'prettydiff', 'prettier', 'jq', 'fixjson']
 endfunction
 
 function! neoformat#formatters#json#jsbeautify() abort


### PR DESCRIPTION
In the README `prettier` comes earlier than `jq` (which makes sense, because it is a formatting tool in the first place, with lots of configuration options and support for EditorConfig, contrary to the `jq`), and README also mentions the support for `jsonfix`.

This change makes the list of formatters align with how it is described in README.