### PR TITLE
Switch tsfmt back to --replace option. Fixes #159

### DIFF
--- a/autoload/neoformat/formatters/typescript.vim
+++ b/autoload/neoformat/formatters/typescript.vim
@@ -5,8 +5,8 @@ endfunction
 function! neoformat#formatters#typescript#tsfmt() abort
     return {
         \ 'exe': 'tsfmt',
-        \ 'args': ['--stdin', '%:p'],
-        \ 'stdin': 1
+        \ 'args': ['--replace', '--baseDir=%:h'],
+        \ 'replace': 1
         \ }
 endfunction
 


### PR DESCRIPTION
Fixes #159. The objection to 4472665 in #37 was that it resulted in tsfmt.json not being respected, which was due to the `tsfmt` call being run on the tmp file, divorced from the tree structure of the original file. Using the `baseDir` option solves this concern.