### PR TITLE
Adds local-to-buffer configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,14 @@ succeeds)
 let g:neoformat_run_all_formatters = 1
 ```
 
+Above options can be activated or deactivated per buffer. For example:
+
+```viml
+    " runs all formatters for current buffer without tab to spaces conversion
+    let b:neoformat_run_all_formatters = 1
+    let b:neoformat_basic_format_retab = 0
+```
+
 Have Neoformat only msg when there is an error
 
 ```viml

--- a/autoload/neoformat.vim
+++ b/autoload/neoformat.vim
@@ -43,7 +43,7 @@ function! s:neoformat(bang, user_input, start_line, end_line) abort
     for formatter in formatters
 
         if &formatprg != '' && split(&formatprg)[0] ==# formatter
-                    \ && get(g:, 'neoformat_try_formatprg', 0)
+                    \ && neoformat#utils#var('neoformat_try_formatprg')
             call neoformat#utils#log('using formatprg')
             let fmt_prg_def = split(&formatprg)
             let definition = {
@@ -120,7 +120,7 @@ function! s:neoformat(bang, user_input, start_line, end_line) abort
 
                 let endmsg = 'no change necessary with ' . cmd.name
             endif
-            if !get(g:, 'neoformat_run_all_formatters', 0)
+            if !neoformat#utils#var('neoformat_run_all_formatters')
                 return neoformat#utils#msg(endmsg)
             endif
             call neoformat#utils#log('running next formatter')
@@ -141,7 +141,7 @@ function! s:neoformat(bang, user_input, start_line, end_line) abort
 endfunction
 
 function! s:get_enabled_formatters(filetype) abort
-    if &formatprg != '' && get(g:, 'neoformat_try_formatprg', 0)
+    if &formatprg != '' && neoformat#utils#var('neoformat_try_formatprg')
         call neoformat#utils#log('adding formatprg to enabled formatters')
         let format_prg_exe = [split(&formatprg)[0]]
     else
@@ -279,17 +279,17 @@ function! s:basic_format() abort
         let g:neoformat_basic_format_trim = 0
     endif
 
-    if g:neoformat_basic_format_align
+    if neoformat#utils#var('neoformat_basic_format_align')
         call neoformat#utils#log('aligning with basic formatter')
         let v = winsaveview()
         silent! execute 'normal gg=G'
         call winrestview(v)
     endif
-    if g:neoformat_basic_format_retab
+    if neoformat#utils#var('neoformat_basic_format_retab')
         call neoformat#utils#log('converting tabs with basic formatter')
         retab
     endif
-    if g:neoformat_basic_format_trim
+    if neoformat#utils#var('neoformat_basic_format_trim')
         call neoformat#utils#log('trimming whitespace with basic formatter')
         " http://stackoverflow.com/q/356126
         let search = @/

--- a/autoload/neoformat/utils.vim
+++ b/autoload/neoformat/utils.vim
@@ -25,3 +25,15 @@ function! s:better_echo(msg) abort
         echom 'Neoformat: ' . a:msg
     endif
 endfunction
+
+function! neoformat#utils#var(name) abort
+    return neoformat#utils#var_default(a:name, 0)
+endfunction
+
+function! neoformat#utils#var_default(name, default) abort
+    if exists('b:' . a:name)
+        return get(b:, a:name)
+    endif
+
+    return get(g:, a:name, a:default)
+endfunction

--- a/doc/neoformat.txt
+++ b/doc/neoformat.txt
@@ -117,19 +117,25 @@ Have Neoformat use &formatprg as a formatter
 <
 Enable basic formatting when a filetype is not found. Disabled by default.
 >
-    " Enable alignment
+    " Enable alignment globally
     let g:neoformat_basic_format_align = 1
 
-    " Enable tab to spaces conversion
+    " Enable tab to spaces conversion globally
     let g:neoformat_basic_format_retab = 1
 
-    " Enable trimmming of trailing whitespace
+    " Enable trimmming of trailing whitespace globally
     let g:neoformat_basic_format_trim = 1
 
 Run all enabled formatters (by default Neoformat stops after the first
 formatter succeeds)
 
     let g:neoformat_run_all_formatters = 1
+
+Above options can be activated or deactivated per buffer. For example:
+
+    " runs all formatters for current buffer without tab to spaces conversion
+    let b:neoformat_run_all_formatters = 1
+    let b:neoformat_basic_format_retab = 0
 
 Have Neoformat only msg when there is an error
 >


### PR DESCRIPTION
I've added checking for `b:` configuration variables. I use `yapf` as my python formatter, but it cannot sort imports. Therefore, for python, and python only I would like to run all enabled formatters, `yapf` and `isort`.

For example, not it is possible to do following.
```viml
let g:neoformat_enabled_python = ['yapf', 'isort']
let g:neoformat_run_all_formatters = 0
augroup filetype_python
    autocmd!
    autocmd FileType python let b:neoformat_run_all_formatters = 1
augroup END
```
Note to README and documentation was added, but I didn't run tests because it couldn't set up testing environment. I am open to provide dedicated Dockerfile for testing purposes, if requested.