### PR TITLE
Fix eslint_d file type detection

### DIFF
--- a/autoload/neoformat/formatters/javascript.vim
+++ b/autoload/neoformat/formatters/javascript.vim
@@ -55,7 +55,7 @@ endfunction
 function! neoformat#formatters#javascript#eslint_d() abort
     return {
         \ 'exe': 'eslint_d',
-        \ 'args': ['--stdin','--fix-to-stdout'],
+        \ 'args': ['--stdin', '--stdin-filename', '%:p', '--fix-to-stdout'],
         \ 'stdin': 1,
         \ }
 endfunction


### PR DESCRIPTION
Without this, using prettier within eslint within eslint_d sometimes throws [No parser could be inferred for file](https://github.com/prettier/prettier/blob/b8ded708485c101e467b37bdb45bca520dd267ef/src/main/options.js#L43).