### PR TITLE
Redirect stderr to log file by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Options:
 | `args`             | list of arguments                                                                                                 | \[]     | optional            |
 | `replace`          | overwrite the file, instead of updating the buffer                                                                | 0       | optional            |
 | `stdin`            | send data to the stdin of the formatter                                                                           | 0       | optional            |
+| `stderr`           | capture stderr output from formatter                                                                              | 0       | optional            |
 | `no_append`        | do not append the `path` of the file to the formatter command, used when the `path` is in the middle of a command | 0       | optional            |
 | `env`              | list of environment variable definitions to be prepended to the formatter command                                 | \[]     | optional            |
 | `valid_exit_codes` | list of valid exit codes for formatters who do not respect common unix practices                                  | \[0]    | optional            |

--- a/autoload/neoformat.vim
+++ b/autoload/neoformat.vim
@@ -258,8 +258,13 @@ function! s:generate_cmd(definition, filetype) abort
     " make sure there aren't any double spaces in the cmd
     let fullcmd = join(split(_fullcmd))
     if !using_stderr
-        let stderr_log = expand(tmp_dir . '/stderr.log')
-        let fullcmd = fullcmd . ' 2> ' . stderr_log
+        if neoformat#utils#should_be_verbose()
+            let stderr_log = expand(tmp_dir . '/stderr.log')
+            let fullcmd = fullcmd . ' 2> ' . stderr_log
+        else
+            let stderr_log = ''
+            let fullcmd = fullcmd . ' 2> ' . '/dev/null'
+        endif
     endif
 
     return {

--- a/autoload/neoformat.vim
+++ b/autoload/neoformat.vim
@@ -102,6 +102,11 @@ function! s:neoformat(bang, user_input, start_line, end_line) abort
         call neoformat#utils#log(v:shell_error)
 
         let process_ran_succesfully = index(cmd.valid_exit_codes, v:shell_error) != -1
+        
+        if cmd.stderr_log != ''
+            call neoformat#utils#log('stderr output redirected to file' . cmd.stderr_log)
+            call neoformat#utils#log_file_content(cmd.stderr_log)
+        endif
         if process_ran_succesfully
             " 1. append the lines that are before and after the formatterd content
             let lines_after = getbufline(bufnr('%'), a:end_line + 1, '$')
@@ -230,6 +235,7 @@ function! s:generate_cmd(definition, filetype) abort
     let no_append = get(a:definition, 'no_append', 0)
     let using_stdin = get(a:definition, 'stdin', 0)
     let using_stderr = get(a:definition, 'stderr', 0)
+    let stderr_log = ''
 
     let filename = expand('%:t')
 
@@ -252,12 +258,14 @@ function! s:generate_cmd(definition, filetype) abort
     " make sure there aren't any double spaces in the cmd
     let fullcmd = join(split(_fullcmd))
     if !using_stderr
-        let fullcmd = fullcmd . ' 2>> ' . expand(tmp_dir . '/stderr.log')
+        let stderr_log = expand(tmp_dir . '/stderr.log')
+        let fullcmd = fullcmd . ' 2> ' . stderr_log
     endif
 
     return {
         \ 'exe':       fullcmd,
         \ 'stdin':     using_stdin,
+        \ 'stderr_log': stderr_log,
         \ 'name':      a:definition.exe,
         \ 'replace':   get(a:definition, 'replace', 0),
         \ 'tmp_file_path': path,

--- a/autoload/neoformat.vim
+++ b/autoload/neoformat.vim
@@ -229,6 +229,7 @@ function! s:generate_cmd(definition, filetype) abort
 
     let no_append = get(a:definition, 'no_append', 0)
     let using_stdin = get(a:definition, 'stdin', 0)
+    let using_stderr = get(a:definition, 'stderr', 0)
 
     let filename = expand('%:t')
 
@@ -250,6 +251,9 @@ function! s:generate_cmd(definition, filetype) abort
     let _fullcmd = join(inline_environment, ' ') . ' ' . executable . ' ' . join(args_expanded) . ' ' . (no_append ? '' : path)
     " make sure there aren't any double spaces in the cmd
     let fullcmd = join(split(_fullcmd))
+    if !using_stderr
+        let fullcmd = fullcmd . ' 2>> ' . expand(tmp_dir . '/stderr.log')
+    endif
 
     return {
         \ 'exe':       fullcmd,

--- a/autoload/neoformat/formatters/haskell.vim
+++ b/autoload/neoformat/formatters/haskell.vim
@@ -13,7 +13,6 @@ endfunction
 function! neoformat#formatters#haskell#stylishhaskell() abort
     return {
         \ 'exe': 'stylish-haskell',
-        \ 'args': ['2>/dev/null'],
         \ 'stdin': 1,
         \ }
 endfunction

--- a/autoload/neoformat/formatters/python.vim
+++ b/autoload/neoformat/formatters/python.vim
@@ -39,7 +39,7 @@ function! neoformat#formatters#python#black() abort
     return {
                 \ 'exe': 'black',
                 \ 'stdin': 1,
-                \ 'args': ['-', '2>/dev/null'],
+                \ 'args': ['-'],
                 \ }
 endfunction
 

--- a/autoload/neoformat/formatters/ruby.vim
+++ b/autoload/neoformat/formatters/ruby.vim
@@ -22,5 +22,6 @@ function! neoformat#formatters#ruby#rubocop() abort
         \ 'exe': 'rubocop',
         \ 'args': ['--auto-correct', '--stdin', '%:p', '2>/dev/null', '|', 'sed "1,/^====================$/d"'],
         \ 'stdin': 1,
+        \ 'stderr': 1
         \ }
 endfunction

--- a/autoload/neoformat/utils.vim
+++ b/autoload/neoformat/utils.vim
@@ -1,11 +1,11 @@
 function! neoformat#utils#log(msg) abort
-    if s:should_be_verbose()
+    if neoformat#utils#should_be_verbose()
         return s:better_echo(a:msg)
     endif
 endfunction
 
 function! neoformat#utils#log_file_content(path) abort
-    if s:should_be_verbose()
+    if neoformat#utils#should_be_verbose()
         return s:better_echo(readfile(a:path))
     endif
 endfunction
@@ -21,7 +21,7 @@ function! neoformat#utils#msg(msg) abort
     return s:better_echo(a:msg)
 endfunction
 
-function! s:should_be_verbose() abort
+function! neoformat#utils#should_be_verbose() abort
     if !exists('g:neoformat_verbose')
         let g:neoformat_verbose = 0
     endif

--- a/autoload/neoformat/utils.vim
+++ b/autoload/neoformat/utils.vim
@@ -1,9 +1,12 @@
 function! neoformat#utils#log(msg) abort
-    if !exists('g:neoformat_verbose')
-        let g:neoformat_verbose = 0
-    endif
-    if &verbose || g:neoformat_verbose
+    if s:should_be_verbose()
         return s:better_echo(a:msg)
+    endif
+endfunction
+
+function! neoformat#utils#log_file_content(path) abort
+    if s:should_be_verbose()
+        return s:better_echo(readfile(a:path))
     endif
 endfunction
 
@@ -16,6 +19,13 @@ function! neoformat#utils#msg(msg) abort
         return
     endif
     return s:better_echo(a:msg)
+endfunction
+
+function! s:should_be_verbose() abort
+    if !exists('g:neoformat_verbose')
+        let g:neoformat_verbose = 0
+    endif
+    return &verbose || g:neoformat_verbose
 endfunction
 
 function! s:better_echo(msg) abort

--- a/doc/neoformat.txt
+++ b/doc/neoformat.txt
@@ -89,6 +89,9 @@ Options:
 | `args`      | list of arguments | default: [] | optional
 | `replace`   | overwrite the file, instead of updating the buffer | default: 0 | optional
 | `stdin`     | send data to the stdin of the formatter | default 0 | optional
+| `stderr`    | used to specify whether stderr output should be read along with
+	     the stdin, otherwise redirects stderr to `stderr.log` file in neoformat's
+	     temporary directory | default 0 | optional
 | `no_append` | do not append the `path` of the file to the formatter command,
 	     used when the `path` is in the middle of a command | default: 0 |
 	     optional


### PR DESCRIPTION
This should fix problem with logs printed on stderr being captured by vim's `system` call. Might be not best solution, it requires some thought if there is not a better way. Particularly, I see two issues with it, it might break formatters that are relying on stderr output (this can be fixed by setting `stderr` flag to 1 in formatter definition) and perhaps if given formatter relies on tricky redirection in `args`. By quick grep, I found that only three formatters make use of `2>/dev/null`, which could be removed if this get merged. Personally, I would like to have such log to inspect if there is no problem with my configuration or whatnot.

Another problem that can occur is that stderr is redirected to `stderr.log` file, and theoretically, this can pose problem if someone was formatting file of such name, with non-stdin formatter, I suppose. This could be prevented, for example, with creation of separate subdirectory for logging files, but I wanted to consult this with you first.