### PR TITLE
Add pydevf as python formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ that caused Neoformat to be invoked.
   - [`yapf`](https://github.com/google/yapf),
     [`autopep8`](https://github.com/hhatto/autopep8),
     [`black`](https://github.com/ambv/black)
+    [`pydevf`](https://github.com/fabioz/PyDev.Formatter)
   - [`isort`](https://github.com/timothycrosley/isort)
   - [`docformatter`](https://github.com/myint/docformatter)
   - [`pyment`](https://github.com/dadadel/pyment)

--- a/autoload/neoformat/formatters/python.vim
+++ b/autoload/neoformat/formatters/python.vim
@@ -1,5 +1,5 @@
 function! neoformat#formatters#python#enabled() abort
-    return ['yapf', 'autopep8', 'black', 'isort', 'docformatter', 'pyment']
+    return ['yapf', 'autopep8', 'black', 'isort', 'docformatter', 'pyment', 'pydevf']
 endfunction
 
 function! neoformat#formatters#python#yapf() abort
@@ -49,5 +49,12 @@ function! neoformat#formatters#python#pyment() abort
                 \ 'exe': 'pyment',
                 \ 'stdin': 1,
                 \ 'args': ['-w', '-'],
+                \ }
+endfunction
+
+function! neoformat#formatters#python#pydevf() abort
+    return {
+                \ 'exe': 'pydevf',
+                \ 'replace': 1,
                 \ }
 endfunction

--- a/doc/neoformat.txt
+++ b/doc/neoformat.txt
@@ -312,9 +312,10 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
 - Python
   - [`yapf`](https://github.com/google/yapf),
     [`autopep8`](https://github.com/hhatto/autopep8),
-    [`black`](https://github.com/ambv/black)
-    [`isort`](https://github.com/timothycrosley/isort)
-    [`docformatter`](https://github.com/myint/docformatter)
+    [`black`](https://github.com/ambv/black),
+    [`pydevf`](https://github.com/fabioz/PyDev.Formatter),
+    [`isort`](https://github.com/timothycrosley/isort),
+    [`docformatter`](https://github.com/myint/docformatter),
     [`pyment`](https://github.com/dadadel/pyment)
 - Reason
   - [`refmt`](https://github.com/facebook/reason)


### PR DESCRIPTION
[Pydevf](https://github.com/fabioz/PyDev.Formatter) is formatter extracted as commandline utility from pydev by its creator.