### PR TITLE
Support ReasonML interface files

### DIFF
--- a/autoload/neoformat/formatters/reason.vim
+++ b/autoload/neoformat/formatters/reason.vim
@@ -6,5 +6,6 @@ function! neoformat#formatters#reason#refmt() abort
     return {
         \ 'exe': 'refmt',
         \ 'stdin': 1,
+        \ 'args': ["--interface=" . (expand('%:e') == "rei" ? "true" : "false")],
         \ }
 endfunction


### PR DESCRIPTION
The previous configuration assumed that ReasonML files would always be
implementation files rather than interfaces files, so it would not be
able to format all files in a project.

The same may need to be done for OCaml.