### PR TITLE
Remove extraneous isort command line flags

### DIFF
--- a/autoload/neoformat/formatters/python.vim
+++ b/autoload/neoformat/formatters/python.vim
@@ -21,7 +21,7 @@ endfunction
 function! neoformat#formatters#python#isort() abort
     return {
                 \ 'exe': 'isort',
-                \ 'args': ['-', '--quiet', '--use-parentheses', '--trailing-comma',],
+                \ 'args': ['-', '--quiet',],
                 \ 'stdin': 1,
                 \ }
 endfunction


### PR DESCRIPTION
The extra isort command line flags added by https://github.com/sbdchd/neoformat/pull/154 are preventing my own projects' isort settings from taking effect.

Having them as command line arguments in neoformat means that they are dictating someone else's isort style preferences, and they cannot be overridden by any configuration files since command line arguments take precedence. This PR removes them.

If someone prefers having `use-parantheses` and/or `trailing-comma` enabled, they should do so through one of the several configuration files that [isort supports](https://github.com/timothycrosley/isort#configuring-isort) at the project-level (eg, `setup.cfg`, `.editorconfig`, `tox.ini`, etc.) or the user-level (`~/.isort.cfg`).