### PR TITLE
Added phpcbf to the available PHP formatters

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ that caused Neoformat to be invoked.
 - PHP
   - [`php_beautifier`](http://pear.php.net/package/PHP_Beautifier)
   - [`php-cs-fixer`](http://cs.sensiolabs.org/)
+  - [`phpcbf`](https://github.com/squizlabs/PHP_CodeSniffer)
 - Proto
   - [`clang-format`](http://clang.llvm.org/docs/ClangFormat.html)
 - Pug (formally Jade)

--- a/autoload/neoformat/formatters/php.vim
+++ b/autoload/neoformat/formatters/php.vim
@@ -1,5 +1,5 @@
 function! neoformat#formatters#php#enabled() abort
-    return ['phpbeautifier', 'phpcsfixer']
+    return ['phpbeautifier', 'phpcsfixer', 'phpcbf']
 endfunction
 
 function! neoformat#formatters#php#phpbeautifier() abort
@@ -13,5 +13,13 @@ function! neoformat#formatters#php#phpcsfixer() abort
            \ 'exe': 'php-cs-fixer',
            \ 'args': ['fix', '-q'],
            \ 'replace': 1,
+           \ }
+endfunction
+
+function! neoformat#formatters#php#phpcbf() abort
+    return {
+           \ 'exe': 'phpcbf',
+           \ 'stdin': 1,
+           \ 'valid_exit_codes': [0,1],
            \ }
 endfunction

--- a/doc/neoformat.txt
+++ b/doc/neoformat.txt
@@ -305,6 +305,7 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
 - PHP
   - [`php_beautifier`](http://pear.php.net/package/PHP_Beautifier)
   - [`php-cs-fixer`](http://cs.sensiolabs.org/)
+  - [`phpcbf`](https://github.com/squizlabs/PHP_CodeSniffer)
 - Proto
   - [`clang-format`](http://clang.llvm.org/docs/ClangFormat.html)
 - Pug (formally Jade)


### PR DESCRIPTION
I saw that #54 lead to there being a feature added to handle non-standard error codes for `phpcbf`'s sake, figured I'd give adding `phpcbf` to the official formatters a shot.