### PR TITLE
Escape spaces in file paths when running cli commands

### DIFF
--- a/autoload/neoformat/formatters/css.vim
+++ b/autoload/neoformat/formatters/css.vim
@@ -40,7 +40,7 @@ endfunction
 function! neoformat#formatters#css#prettier() abort
     return {
         \ 'exe': 'prettier',
-        \ 'args': ['--stdin', '--stdin-filepath', '%:p', '--parser', 'css'],
+        \ 'args': ['--stdin', '--stdin-filepath', '"%:p"', '--parser', 'css'],
         \ 'stdin': 1
         \ }
 endfunction

--- a/autoload/neoformat/formatters/graphql.vim
+++ b/autoload/neoformat/formatters/graphql.vim
@@ -5,7 +5,7 @@ endfunction
 function! neoformat#formatters#graphql#prettier() abort
     return {
         \ 'exe': 'prettier',
-        \ 'args': ['--stdin', '--stdin-filepath', '%:p', '--parser', 'graphql'],
+        \ 'args': ['--stdin', '--stdin-filepath', '"%:p"', '--parser', 'graphql'],
         \ 'stdin': 1
         \ }
 endfunction

--- a/autoload/neoformat/formatters/javascript.vim
+++ b/autoload/neoformat/formatters/javascript.vim
@@ -39,7 +39,7 @@ endfunction
 function! neoformat#formatters#javascript#prettier() abort
     return {
         \ 'exe': 'prettier',
-        \ 'args': ['--stdin', '--stdin-filepath', '%:p'],
+        \ 'args': ['--stdin', '--stdin-filepath', '"%:p"'],
         \ 'stdin': 1,
         \ }
 endfunction
@@ -47,7 +47,7 @@ endfunction
 function! neoformat#formatters#javascript#prettiereslint() abort
     return {
         \ 'exe': 'prettier-eslint',
-        \ 'args': ['--stdin', '--stdin-filepath', '%:p'],
+        \ 'args': ['--stdin', '--stdin-filepath', '"%:p"'],
         \ 'stdin': 1,
         \ }
 endfunction
@@ -55,7 +55,7 @@ endfunction
 function! neoformat#formatters#javascript#eslint_d() abort
     return {
         \ 'exe': 'eslint_d',
-        \ 'args': ['--stdin', '--stdin-filename', '%:p', '--fix-to-stdout'],
+        \ 'args': ['--stdin', '--stdin-filename', '"%:p"', '--fix-to-stdout'],
         \ 'stdin': 1,
         \ }
 endfunction

--- a/autoload/neoformat/formatters/json.vim
+++ b/autoload/neoformat/formatters/json.vim
@@ -20,7 +20,7 @@ endfunction
 function! neoformat#formatters#json#prettier() abort
     return {
         \ 'exe': 'prettier',
-        \ 'args': ['--stdin', '--stdin-filepath', '%:p', '--parser', 'json'],
+        \ 'args': ['--stdin', '--stdin-filepath', '"%:p"', '--parser', 'json'],
         \ 'stdin': 1,
         \ }
 endfunction

--- a/autoload/neoformat/formatters/markdown.vim
+++ b/autoload/neoformat/formatters/markdown.vim
@@ -5,7 +5,7 @@ endfunction
 function! neoformat#formatters#markdown#prettier() abort
     return {
         \ 'exe': 'prettier',
-        \ 'args': ['--stdin', '--stdin-filepath', '%:p'],
+        \ 'args': ['--stdin', '--stdin-filepath', '"%:p"'],
         \ 'stdin': 1,
         \ }
 endfunction

--- a/autoload/neoformat/formatters/ocaml.vim
+++ b/autoload/neoformat/formatters/ocaml.vim
@@ -11,6 +11,6 @@ endfunction
 function! neoformat#formatters#ocaml#ocamlformat() abort
     return {
         \ 'exe': 'ocamlformat',
-        \ 'args': ['--name', '%:p']
+        \ 'args': ['--name', '"%:p"']
         \ }
 endfunction

--- a/autoload/neoformat/formatters/ruby.vim
+++ b/autoload/neoformat/formatters/ruby.vim
@@ -20,7 +20,7 @@ endfunction
 function! neoformat#formatters#ruby#rubocop() abort
      return {
         \ 'exe': 'rubocop',
-        \ 'args': ['--auto-correct', '--stdin', '%:p', '2>/dev/null', '|', 'sed "1,/^====================$/d"'],
+        \ 'args': ['--auto-correct', '--stdin', '"%:p"', '2>/dev/null', '|', 'sed "1,/^====================$/d"'],
         \ 'stdin': 1,
         \ 'stderr': 1
         \ }

--- a/autoload/neoformat/formatters/typescript.vim
+++ b/autoload/neoformat/formatters/typescript.vim
@@ -13,7 +13,7 @@ endfunction
 function! neoformat#formatters#typescript#prettier() abort
     return {
         \ 'exe': 'prettier',
-        \ 'args': ['--stdin', '--stdin-filepath', '%:p', '--parser', 'typescript'],
+        \ 'args': ['--stdin', '--stdin-filepath', '"%:p"', '--parser', 'typescript'],
         \ 'stdin': 1
         \ }
 endfunction

--- a/autoload/neoformat/formatters/vue.vim
+++ b/autoload/neoformat/formatters/vue.vim
@@ -5,7 +5,7 @@ endfunction
 function! neoformat#formatters#vue#prettier() abort
     return {
         \ 'exe': 'prettier',
-        \ 'args': ['--stdin', '--stdin-filepath', '%:p', '--parser', 'vue'],
+        \ 'args': ['--stdin', '--stdin-filepath', '"%:p"', '--parser', 'vue'],
         \ 'stdin': 1
         \ }
 endfunction

--- a/autoload/neoformat/formatters/yaml.vim
+++ b/autoload/neoformat/formatters/yaml.vim
@@ -13,7 +13,7 @@ endfunction
 function! neoformat#formatters#yaml#prettier() abort
     return {
             \ 'exe': 'prettier',
-            \ 'args': ['--stdin', '--stdin-filepath', '%:p', '--parser', 'yaml'],
+            \ 'args': ['--stdin', '--stdin-filepath', '"%:p"', '--parser', 'yaml'],
             \ 'stdin': 1
             \ }
 endfunction


### PR DESCRIPTION
When editing files with spaces in their paths neoformat often fails. Most annoying example is files within iCloud Drive on Mac: `~/Library/Mobile Documents/iCloud...`