### PR TITLE
Smoother integration with OCamlformat

### DIFF
--- a/autoload/neoformat/formatters/ocaml.vim
+++ b/autoload/neoformat/formatters/ocaml.vim
@@ -11,6 +11,8 @@ endfunction
 function! neoformat#formatters#ocaml#ocamlformat() abort
     return {
         \ 'exe': 'ocamlformat',
-        \ 'args': ['--name', '"%:p"']
+        \ 'no_append': 1,
+        \ 'stdin': 1,
+        \ 'args': ['--name', '"%:p"', '-']
         \ }
 endfunction


### PR DESCRIPTION
Since https://github.com/ocaml-ppx/ocamlformat/pull/353 , ocamlformat can read from stdin. This provides a much tighter integration with neoformat (no ugly messages in vim's console).

I confirmed this works on my vim