### PR TITLE
Pad formatter output based on the previous line

### DIFF
--- a/autoload/neoformat.vim
+++ b/autoload/neoformat.vim
@@ -102,17 +102,21 @@ function! s:neoformat(bang, user_input, start_line, end_line) abort
         call neoformat#utils#log(v:shell_error)
 
         let process_ran_succesfully = index(cmd.valid_exit_codes, v:shell_error) != -1
-        
+
         if cmd.stderr_log != ''
             call neoformat#utils#log('stderr output redirected to file' . cmd.stderr_log)
             call neoformat#utils#log_file_content(cmd.stderr_log)
         endif
         if process_ran_succesfully
-            " 1. append the lines that are before and after the formatterd content
+            " 1. append the lines that are before and after the formatted content
             let lines_after = getbufline(bufnr('%'), a:end_line + 1, '$')
             let lines_before = getbufline(bufnr('%'), 1, a:start_line - 1)
 
+            if get(a:definition, 'indent_output')
+                let stdout = s:indent_output(stdout, lines_before)
+            endif
             let new_buffer = lines_before + stdout + lines_after
+
             if new_buffer !=# original_buffer
 
                 call s:deletelines(len(new_buffer), line('$'))
@@ -143,6 +147,25 @@ function! s:neoformat(bang, user_input, start_line, end_line) abort
     elseif len(formatters_failed) == 0
         call neoformat#utils#msg('no change necessary')
     endif
+endfunction
+
+function! s:indent_output(output, lines_before)
+    " guess indent based on the previous line
+    let prev_line = a:lines_before[-1]
+		" see if the line is indented with tabs
+    let tab_count = matchend(prev_line, '^\t*')
+
+		if tab_count > 0
+        let indent_str = repeat("\t", tab_count + 1)
+		else
+        let indent_str = repeat(' ', matchend(prev_line, '^\s*') + &shiftwidth)
+		endif
+
+		for i in range(0, len(a:output) - 1, 1)
+				let a:output[i] = indent_str . a:output[i]
+		endfor
+
+		return a:output
 endfunction
 
 function! s:get_enabled_formatters(filetype) abort

--- a/autoload/neoformat.vim
+++ b/autoload/neoformat.vim
@@ -112,7 +112,7 @@ function! s:neoformat(bang, user_input, start_line, end_line) abort
             let lines_after = getbufline(bufnr('%'), a:end_line + 1, '$')
             let lines_before = getbufline(bufnr('%'), 1, a:start_line - 1)
 
-            if get(a:definition, 'indent_output')
+            if get(definition, 'indent_output')
                 let stdout = s:indent_output(stdout, lines_before)
             endif
             let new_buffer = lines_before + stdout + lines_after
@@ -150,6 +150,10 @@ function! s:neoformat(bang, user_input, start_line, end_line) abort
 endfunction
 
 function! s:indent_output(output, lines_before)
+    if empty(a:output)
+        return []
+    endif
+
     " guess indent based on the previous line
     let prev_line = a:lines_before[-1]
 		" see if the line is indented with tabs

--- a/doc/neoformat.txt
+++ b/doc/neoformat.txt
@@ -96,6 +96,7 @@ Options:
 	     used when the `path` is in the middle of a command | default: 0 |
 	     optional
 | `env`       | list of environment variables to prepend to the command | default: [] | optional
+| `indent_output` | wether or not to indent the output automatically, based on the previous line | default: 0 | optional
 
 | `valid_exit_codes` | list of valid exit codes for formatters who do not respect common unix practices | \[0] | optional
 


### PR DESCRIPTION
As discussed on #204, it's possible to employ a naive way of "deducing" the correct indentation based on the previous line. That being said, this is in the same category of other post-processing output functions that the user could be interested in doing. Maybe introducing the "post-callbacks" option is more flexible than this.

**No tests yet** as the thought above has been presented and that would change the code quite a bit.