### PR TITLE
Stick with Elm v0.19

### DIFF
--- a/autoload/neoformat/formatters/elm.vim
+++ b/autoload/neoformat/formatters/elm.vim
@@ -5,7 +5,7 @@ endfunction
 function! neoformat#formatters#elm#elmformat() abort
     return {
         \ 'exe': 'elm-format',
-        \ 'args': ['--stdin'],
+        \ 'args': ['--stdin', '--elm-version=0.19'],
         \ 'stdin': 1,
         \ }
 endfunction


### PR DESCRIPTION
Currently, `elm-format` does not work well with Neoformat because it cannot detect a version of Elm which is currently used unless it's executed at the top directory containing `elm.json` for v0.19 or `elm-package.json` for v0.18. This PR makes it work with the latest version of 0.19 by passing Elm's verion explicitly as a command line argument.