### PR TITLE
[Python]: Pass the 'quiet' argument to Black

### DIFF
--- a/autoload/neoformat/formatters/python.vim
+++ b/autoload/neoformat/formatters/python.vim
@@ -39,7 +39,7 @@ function! neoformat#formatters#python#black() abort
     return {
                 \ 'exe': 'black',
                 \ 'stdin': 1,
-                \ 'args': ['-'],
+                \ 'args': ['-q', '-'],
                 \ }
 endfunction
 


### PR DESCRIPTION
I haven't had the opportunity to reproduce this on a Linux machine, but
on my Windows setup, running the Black formatter appends the pretty
summary to my buffer. The problem is solved by asking Black to be
'quiet'.

Example of the content appended to my buffer (prior to this change):
```
reformatted -
All done! \u2728 \U0001f370 \u2728
1 file reformatted.
```