### PR TITLE
Add nimpretty as formatter for nim files

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,8 @@ that caused Neoformat to be invoked.
 - Markdown
   - [`remark`](https://github.com/wooorm/remark)
     [`prettier`](https://github.com/prettier/prettier)
+- Nim
+  - `nimpretty` (ships with [`nim`](https://nim-lang.org/))
 - Objective-C
   - [`uncrustify`](http://uncrustify.sourceforge.net),
     [`clang-format`](http://clang.llvm.org/docs/ClangFormat.html),

--- a/autoload/neoformat/formatters/nim.vim
+++ b/autoload/neoformat/formatters/nim.vim
@@ -1,0 +1,11 @@
+function! neoformat#formatters#nim#enabled() abort
+    return ['nimpretty']
+endfunction
+
+function! neoformat#formatters#nim#nimpretty() abort
+    return {
+        \ 'exe': 'nimpretty',
+        \ 'args': ['--backup:off'],
+        \ 'replace': 1,
+        \ }
+endfunction

--- a/doc/neoformat.txt
+++ b/doc/neoformat.txt
@@ -299,6 +299,8 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
 - Markdown
   - [`remark`](https://github.com/wooorm/remark)
     [`prettier`](https://github.com/prettier/prettier),
+- Nim
+  - nimpretty (ships with [nim](https://nim-lang.org/)),
 - Objective-C
   - [`uncrustify`](http://uncrustify.sourceforge.net),
     [`clang-format`](http://clang.llvm.org/docs/ClangFormat.html),


### PR DESCRIPTION
`nimpretty` is the formatter that comes bundles with [Nim][]! This PR adds support for it to Neoformat.

[Nim]: https://nim-lang.org/