### PR TITLE
Run formatters async on neovim 

### DIFF
--- a/test/Dockerfile.nvim
+++ b/test/Dockerfile.nvim
@@ -1,0 +1,24 @@
+FROM python:3.6.8-stretch
+
+RUN apt-get update
+RUN apt-get install -y curl
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
+
+RUN apt-get install -y nodejs sudo build-essential libssl-dev git
+
+RUN wget https://github.com/neovim/neovim/archive/v0.3.4.tar.gz
+RUN tar -zxvf v0.3.4.tar.gz
+RUN apt-get install -y cmake
+RUN apt-get install -y libtool-bin
+RUN apt-get install -y gettext
+RUN cd neovim-0.3.4 && make CMAKE_BUILD_TYPE=RelWithDebInfo &&  make install
+
+WORKDIR /home/
+ADD test/install_docker.sh test/
+RUN test/install_docker.sh
+
+ADD test/requirements.txt test/
+RUN pip3 install -r test/requirements.txt
+
+ADD . .
+RUN cd test && pytest -v test.py

--- a/test/Dockerfile.vim8
+++ b/test/Dockerfile.vim8
@@ -1,0 +1,21 @@
+FROM python:3.6.8-stretch
+
+RUN apt-get update
+RUN apt-get install -y curl
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
+
+RUN apt-get install -y nodejs sudo build-essential libssl-dev git
+
+RUN wget https://github.com/vim/vim/archive/v8.1.1234.tar.gz
+RUN tar -zxvf v8.1.1234.tar.gz
+RUN cd vim-8.1.1234 && ./configure && make install
+
+WORKDIR /home/
+ADD test/install_docker.sh test/
+RUN test/install_docker.sh
+
+ADD test/requirements.txt test/
+RUN pip3 install -r test/requirements.txt
+
+ADD . .
+RUN cd test && pytest -v test.py

--- a/test/install_docker.sh
+++ b/test/install_docker.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Formatters
+npm install -g csscomb@3.1.7
+npm install -g prettydiff@99.0.1
+npm install -g js-beautify@1.6.2 # for css-beautify
+npm install -g typescript@2.0.6
+npm install -g typescript-formatter@4.0.1
+pip3 install yapf==0.14.0
+
+# Linter(s)
+if ! hash vint 2>/dev/null; then
+    pip3 install vim-vint
+fi
+
+# Vader
+if [ ! -d "$HOME/.vim/plugged/vader.vim" ]; then
+    git clone https://github.com/junegunn/vader.vim.git ~/.vim/plugged/vader.vim
+fi
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+export PATH=$PATH:"$DIR"/bin
+echo $PATH

--- a/test/test.py
+++ b/test/test.py
@@ -26,7 +26,7 @@ def test_formatters():
     for filename in listdir('before'):
         output_file = '/tmp/neoformat_' + filename
         formatter = filename.split('.')[0]
-        cmd = f'nvim -u vimrc -c "set verbose=1 | Neoformat {formatter} | w! {output_file} | q! " --headless ./before/{filename}'
+        cmd = f'nvim -u vimrc -c "set verbose=1 | Neoformat {formatter} | sleep 1 | w! {output_file} | q! " --headless ./before/{filename}'
         run_cmd(cmd)
         before = readlines(output_file)
         after = readlines('./after/' + filename)
@@ -45,7 +45,7 @@ def test_visual_selection_multi_filetype():
         (filetype, start_line, end_line) = test
         print(start_line)
         vim_cmd = f'{start_line},{end_line}Neoformat! {filetype}'
-        cmd = f'nvim -u vimrc -c "set verbose=1 | {vim_cmd} | wq " --headless {output_file}'
+        cmd = f'nvim -u vimrc -c "set verbose=1 | {vim_cmd} | sleep 1 | wq " --headless {output_file}'
         run_cmd(cmd)
 
     before = readlines(output_file)
@@ -62,7 +62,7 @@ def test_visual_selection_with_filetype_and_formatter():
     for filename in listdir(dir_before):
         (filetype, formatter, start_line, end_line) = filename.split('_')
         output_file = '/tmp/neoformat_' + filename
-        cmd = f'nvim -u vimrc -c "set verbose=1 | {start_line},{end_line}Neoformat! {filetype} {formatter} | w! {output_file} | q! " --headless {dir_before + filename}'
+        cmd = f'nvim -u vimrc -c "set verbose=1 | {start_line},{end_line}Neoformat! {filetype} {formatter} | sleep 1 |w! {output_file} | q! " --headless {dir_before + filename}'
         run_cmd(cmd)
         before = readlines(output_file)
         after = readlines(dir_after + filename)
@@ -81,7 +81,7 @@ def test_formatprg_with_neoformat():
     let &formatprg = 'css-beautify -s 6 -n'
     let g:neoformat_try_formatprg = 1
     '''
-    cmd = f'nvim -u vimrc -c "set verbose=1 | {viml} | Neoformat | w! {output_file} | q! " --headless {dir_before + filename}'
+    cmd = f'nvim -u vimrc -c "set verbose=1 | {viml} | Neoformat | sleep 1 | w! {output_file} | q! " --headless {dir_before + filename}'
     run_cmd(cmd)
     before = readlines(output_file)
     after = readlines('./after/cssbeautify-indent-6.css')
@@ -99,7 +99,7 @@ def test_formatprg_without_enable():
     viml = '''
     let &formatprg = 'css-beautify -s 6 -n'
     '''
-    cmd = f'nvim -u vimrc -c "set verbose=1 | {viml} | Neoformat | w! {output_file} | q! " --headless {dir_before + filename}'
+    cmd = f'nvim -u vimrc -c "set verbose=1 | {viml} | Neoformat | sleep 1 | w! {output_file} | q! " --headless {dir_before + filename}'
     run_cmd(cmd)
     before = readlines(output_file)
     after = readlines('./after/cssbeautify.css')

--- a/test/test.py
+++ b/test/test.py
@@ -5,13 +5,21 @@ import subprocess
 from os import listdir
 from shutil import copyfile
 
-def run_vim_cmd(cmd, filename=''):
-    cmd = f'nvim -u vimrc -c "set verbose=1 | {cmd} | wq " --headless {filename}'
-    return run_cmd(cmd)
-
-
 def run_cmd(cmd):
     return subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True).wait()
+
+def detect_vim():
+    if run_cmd("nvim --version") == 0:
+        return "nvim --headless"
+    if run_cmd("vim --version") == 0:
+        return "vim"
+
+VIM = detect_vim()
+
+def run_vim_cmd(cmd, filename=''):
+    cmd = f'{VIM} -u vimrc -c "set verbose=1 | {cmd} | wq " {filename}'
+    return run_cmd(cmd)
+
 
 
 def readlines(filename):
@@ -26,7 +34,7 @@ def test_formatters():
     for filename in listdir('before'):
         output_file = '/tmp/neoformat_' + filename
         formatter = filename.split('.')[0]
-        cmd = f'nvim -u vimrc -c "set verbose=1 | Neoformat {formatter} | sleep 1 | w! {output_file} | q! " --headless ./before/{filename}'
+        cmd = f'{VIM} -u vimrc -c "set verbose=1 | Neoformat {formatter} | sleep 1 | w! {output_file} | q! " ./before/{filename}'
         run_cmd(cmd)
         before = readlines(output_file)
         after = readlines('./after/' + filename)
@@ -45,7 +53,7 @@ def test_visual_selection_multi_filetype():
         (filetype, start_line, end_line) = test
         print(start_line)
         vim_cmd = f'{start_line},{end_line}Neoformat! {filetype}'
-        cmd = f'nvim -u vimrc -c "set verbose=1 | {vim_cmd} | sleep 1 | wq " --headless {output_file}'
+        cmd = f'{VIM} -u vimrc -c "set verbose=1 | {vim_cmd} | sleep 1 | wq " {output_file}'
         run_cmd(cmd)
 
     before = readlines(output_file)
@@ -62,7 +70,7 @@ def test_visual_selection_with_filetype_and_formatter():
     for filename in listdir(dir_before):
         (filetype, formatter, start_line, end_line) = filename.split('_')
         output_file = '/tmp/neoformat_' + filename
-        cmd = f'nvim -u vimrc -c "set verbose=1 | {start_line},{end_line}Neoformat! {filetype} {formatter} | sleep 1 |w! {output_file} | q! " --headless {dir_before + filename}'
+        cmd = f'{VIM} -u vimrc -c "set verbose=1 | {start_line},{end_line}Neoformat! {filetype} {formatter} | sleep 1 |w! {output_file} | q! " {dir_before + filename}'
         run_cmd(cmd)
         before = readlines(output_file)
         after = readlines(dir_after + filename)
@@ -81,7 +89,7 @@ def test_formatprg_with_neoformat():
     let &formatprg = 'css-beautify -s 6 -n'
     let g:neoformat_try_formatprg = 1
     '''
-    cmd = f'nvim -u vimrc -c "set verbose=1 | {viml} | Neoformat | sleep 1 | w! {output_file} | q! " --headless {dir_before + filename}'
+    cmd = f'{VIM} -u vimrc -c "set verbose=1 | {viml} | Neoformat | sleep 1 | w! {output_file} | q! " {dir_before + filename}'
     run_cmd(cmd)
     before = readlines(output_file)
     after = readlines('./after/cssbeautify-indent-6.css')
@@ -99,7 +107,7 @@ def test_formatprg_without_enable():
     viml = '''
     let &formatprg = 'css-beautify -s 6 -n'
     '''
-    cmd = f'nvim -u vimrc -c "set verbose=1 | {viml} | Neoformat | sleep 1 | w! {output_file} | q! " --headless {dir_before + filename}'
+    cmd = f'{VIM} -u vimrc -c "set verbose=1 | {viml} | Neoformat | sleep 1 | w! {output_file} | q! " {dir_before + filename}'
     run_cmd(cmd)
     before = readlines(output_file)
     after = readlines('./after/cssbeautify.css')
@@ -110,7 +118,7 @@ def test_vader():
     '''
     run *.vader tests
     '''
-    cmd = f'nvim -u vimrc -c "Vader! *.vader" --headless'
+    cmd = f'{VIM} -u vimrc -c "Vader! *.vader"'
     exit_code = run_cmd(cmd)
     assert exit_code == 0
 
@@ -119,7 +127,7 @@ def test_autocompletion():
     '''
     run the vim autocompletion tests
     '''
-    cmd = f'nvim -u vimrc -c "source autocomplete_test.vim" --headless'
+    cmd = f'{VIM} -u vimrc -c "source autocomplete_test.vim"'
     exit_code = run_cmd(cmd)
     assert exit_code == 0
 

--- a/test/vimrc
+++ b/test/vimrc
@@ -13,6 +13,8 @@ set noswapfile
 
 " seems like cp doesn't have standard exit codes
 let g:neoformat_copy_cp = {
-      \ 'exe': 'exit64',
+      \ 'exe': '/bin/bash',
+      \ 'args': ['-c', '"(exit 64)"'],
+      \ 'stdin': v:true,
       \ 'valid_exit_codes': [1, 64],
       \ }


### PR DESCRIPTION
Hello,

My attempt to solve #182 (and #106, I guess). This is my first attempt at Vimscript so it was a lot of trial-error and copy pasting, any feedback is welcome.

Instead of executing  formatters one by one, it prepares all commands in a loop, and then runs `s:run_formatters` which executes 1 formatter and calls `s:job_exit`, which executes `s:run_formatters` again.

I tried to make it work with vim8, but stumbled on `job_start` not being friendly with `2> ...` for some reason.

I also added Dockerfiles with neovim and vim8, so both versions can be tested. Experience with vim8 is not as smooth as with neovim due to lack of `--headless` mode, so the messages are not visible in CI 🤷‍♂ 
I also had to add `sleep 1` to tests, because `Neoformat` returns right away.