### PR TITLE
Support for stylelint --fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ that caused Neoformat to be invoked.
   - `css-beautify` (ships with [`js-beautify`](https://github.com/beautify-web/js-beautify)),
     [`prettydiff`](https://github.com/prettydiff/prettydiff),
     [`stylefmt`](https://github.com/morishitter/stylefmt),
+    [`stylelint`](https://stylelint.io/),
     [`csscomb`](http://csscomb.com),
     [`prettier`](https://github.com/prettier/prettier)
 - CSV
@@ -299,7 +300,8 @@ that caused Neoformat to be invoked.
 - Less
   - [`csscomb`](http://csscomb.com),
     [`prettydiff`](https://github.com/prettydiff/prettydiff),
-    [`prettier`](https://github.com/prettier/prettier)
+    [`prettier`](https://github.com/prettier/prettier),
+    [`stylelint`](https://stylelint.io/)
 - Lua
   - [`luaformatter`](https://github.com/LuaDevelopmentTools/luaformatter)
 - Markdown
@@ -349,6 +351,7 @@ that caused Neoformat to be invoked.
   - [`rustfmt`](https://github.com/rust-lang-nursery/rustfmt)
 - Sass
   - [`sass-convert`](http://sass-lang.com/documentation/#executables),
+    [`stylelint`](https://stylelint.io/),
     [`csscomb`](http://csscomb.com)
 - Sbt
   - [`scalafmt`](http://scalameta.org/scalafmt/)
@@ -357,6 +360,7 @@ that caused Neoformat to be invoked.
     [`scalafmt`](http://scalameta.org/scalafmt/)
 - SCSS
   - [`sass-convert`](http://sass-lang.com/documentation/#executables),
+    [`stylelint`](https://stylelint.io/),
     [`stylefmt`](https://github.com/morishitter/stylefmt),
     [`prettydiff`](https://github.com/prettydiff/prettydiff),
     [`csscomb`](http://csscomb.com),

--- a/autoload/neoformat/formatters/css.vim
+++ b/autoload/neoformat/formatters/css.vim
@@ -1,5 +1,5 @@
 function! neoformat#formatters#css#enabled() abort
-    return ['stylefmt', 'prettier', 'cssbeautify', 'prettydiff', 'csscomb']
+    return ['stylelint', 'stylefmt', 'prettier', 'cssbeautify', 'prettydiff', 'csscomb']
 endfunction
 
 function! neoformat#formatters#css#cssbeautify() abort
@@ -43,4 +43,12 @@ function! neoformat#formatters#css#prettier() abort
         \ 'args': ['--stdin', '--stdin-filepath', '"%:p"', '--parser', 'css'],
         \ 'stdin': 1
         \ }
+endfunction
+
+function! neoformat#formatters#css#stylelint() abort
+    return {
+            \ 'exe': 'stylelint',
+            \ 'args': ['--fix'],
+            \ 'stdin': 1,
+            \ }
 endfunction

--- a/autoload/neoformat/formatters/less.vim
+++ b/autoload/neoformat/formatters/less.vim
@@ -1,5 +1,5 @@
 function! neoformat#formatters#less#enabled() abort
-    return ['prettier', 'csscomb', 'prettydiff']
+    return ['stylelint', 'prettier', 'csscomb', 'prettydiff']
 endfunction
 
 function! neoformat#formatters#less#csscomb() abort
@@ -12,4 +12,8 @@ endfunction
 
 function! neoformat#formatters#less#prettier() abort
     return neoformat#formatters#css#prettier()
+endfunction
+
+function! neoformat#formatters#less#stylelint() abort
+    return neoformat#formatters#css#stylelint()
 endfunction

--- a/autoload/neoformat/formatters/sass.vim
+++ b/autoload/neoformat/formatters/sass.vim
@@ -1,5 +1,5 @@
 function! neoformat#formatters#sass#enabled() abort
-   return ['sassconvert', 'csscomb']
+   return ['sassconvert', 'stylelint', 'csscomb']
 endfunction
 
 function! neoformat#formatters#sass#sassconvert() abort
@@ -14,3 +14,6 @@ function! neoformat#formatters#sass#csscomb() abort
     return neoformat#formatters#css#csscomb()
 endfunction
 
+function! neoformat#formatters#sass#stylelint() abort
+    return neoformat#formatters#css#stylelint()
+endfunction

--- a/autoload/neoformat/formatters/scss.vim
+++ b/autoload/neoformat/formatters/scss.vim
@@ -1,5 +1,5 @@
 function! neoformat#formatters#scss#enabled() abort
-   return ['sassconvert', 'stylefmt', 'prettier', 'prettydiff', 'csscomb']
+   return ['sassconvert', 'stylelint', 'stylefmt', 'prettier', 'prettydiff', 'csscomb']
 endfunction
 
 function! neoformat#formatters#scss#sassconvert() abort
@@ -24,4 +24,8 @@ endfunction
 
 function! neoformat#formatters#scss#prettier() abort
     return neoformat#formatters#css#prettier()
+endfunction
+
+function! neoformat#formatters#scss#stylelint() abort
+    return neoformat#formatters#css#stylelint()
 endfunction

--- a/doc/neoformat.txt
+++ b/doc/neoformat.txt
@@ -233,6 +233,7 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
     [`prettier`](https://github.com/prettier/prettier),
     [`prettydiff`](https://github.com/prettydiff/prettydiff),
     [`stylefmt`](https://github.com/morishitter/stylefmt),
+    [`stylelint`](https://stylelint.io/),
     [`csscomb`](http://csscomb.com)
 - CSV
   - [`prettydiff`](https://github.com/prettydiff/prettydiff)
@@ -293,7 +294,8 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
 - Less
   - [`csscomb`](http://csscomb.com),
     [`prettier`](https://github.com/prettier/prettier),
-    [`prettydiff`](https://github.com/prettydiff/prettydiff)
+    [`prettydiff`](https://github.com/prettydiff/prettydiff),
+    [`stylelint`](https://stylelint.io/)
 - Lua
   - [`luaformatter`](https://github.com/LuaDevelopmentTools/luaformatter)
 - Markdown
@@ -343,6 +345,7 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
   - [`rustfmt`](https://github.com/rust-lang-nursery/rustfmt)
 - Sass
   - [`sass-convert`](http://sass-lang.com/documentation/#executables),
+    [`stylelint`](https://stylelint.io/),
     [`csscomb`](http://csscomb.com)
 - Sbt
   - [`scalafmt`](http://scalameta.org/scalafmt/)
@@ -352,6 +355,7 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
 - SCSS
   - [`sass-convert`](http://sass-lang.com/documentation/#executables),
     [`stylefmt`](https://github.com/morishitter/stylefmt),
+    [`stylelint`](https://stylelint.io/)
     [`prettier`](https://github.com/prettier/prettier),
     [`prettydiff`](https://github.com/prettydiff/prettydiff),
     [`csscomb`](http://csscomb.com)


### PR DESCRIPTION
Adds support for `stylelint --fix` which is [recommended by stylefmt](https://github.com/morishitter/stylefmt#notice-consider-other-tools-before-adopting-stylefmt)