### PR TITLE
Fix issues when running multiple formatters and one formatter add/removes lines

### DIFF
--- a/autoload/neoformat.vim
+++ b/autoload/neoformat.vim
@@ -40,6 +40,7 @@ function! s:neoformat(bang, user_input, start_line, end_line) abort
 
     let formatters_failed = []
     let formatters_changed = []
+    let end_line = a:end_line
     for formatter in formatters
 
         if &formatprg != '' && split(&formatprg)[0] ==# formatter
@@ -75,7 +76,7 @@ function! s:neoformat(bang, user_input, start_line, end_line) abort
             continue
         endif
 
-        let stdin = getbufline(bufnr('%'), a:start_line, a:end_line)
+        let stdin = getbufline(bufnr('%'), a:start_line, end_line)
         let original_buffer = getbufline(bufnr('%'), 1, '$')
 
         call neoformat#utils#log(stdin)
@@ -108,12 +109,15 @@ function! s:neoformat(bang, user_input, start_line, end_line) abort
             call neoformat#utils#log_file_content(cmd.stderr_log)
         endif
         if process_ran_succesfully
-            " 1. append the lines that are before and after the formatterd content
-            let lines_after = getbufline(bufnr('%'), a:end_line + 1, '$')
+            " 1. append the lines that are before and after the formatted content
+            let lines_after = getbufline(bufnr('%'), end_line + 1, '$')
             let lines_before = getbufline(bufnr('%'), 1, a:start_line - 1)
 
             let new_buffer = lines_before + stdout + lines_after
             if new_buffer !=# original_buffer
+                " previous formatter may have added or removed lines which moves
+                " the end_line for the next formatter
+                let end_line = end_line + len(stdout) - len(stdin)
 
                 call s:deletelines(len(new_buffer), line('$'))
 


### PR DESCRIPTION
When running multiple formatters, Neoformat doesn't account for lines being added or removed by individual formatters. It just passes the same number of lines to next formatter which can cause issues like the bottom of the file not being formatted or syntax errors.

For example, with this configuration:

```vim
let g:neoformat_run_all_formatters = 1
let g:neoformat_enabled_python = ['isort', 'yapf']
```

Before:

![before](https://user-images.githubusercontent.com/773401/59162001-26c04700-8ac0-11e9-9698-98ac3b784100.gif)

* Run 1: Input is 4 lines. isort inserts 3 blank lines and outputs 7 lines. Only the first 4 lines get passed to yapf which causes the function to not get formatted and a blank line gets removed.
* Run 2: Input is 6 lines. isort inserts one blank line and outputs 7 lines. Only the first 6 lines get passed to yapf which fails with a syntax error (the missing line being the function body).
* Run 3: Input is 7 lines and isort doesn't insert any more lines, so the file gets formatted correctly.

After:

![after](https://user-images.githubusercontent.com/773401/59162032-b1a14180-8ac0-11e9-81ed-531148ce1b58.gif)

* The file is formatted correctly after one run.