### PR TITLE
docs(typescript): add `eslint_d` docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,7 @@ that caused Neoformat to be invoked.
   - [`tsfmt`](https://github.com/vvakame/typescript-formatter),
     [`prettier`](https://github.com/prettier/prettier),
     [`tslint`](https://palantir.github.io/tslint)
+    [`eslint_d`](https://github.com/mantoni/eslint_d.js)
     [`clang-format`](http://clang.llvm.org/docs/ClangFormat.html),
 - VALA
   - [`uncrustify`](http://uncrustify.sourceforge.net)

--- a/doc/neoformat.txt
+++ b/doc/neoformat.txt
@@ -375,6 +375,7 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
   - [`tsfmt`](https://github.com/vvakame/typescript-formatter),
     [`prettier`](https://github.com/prettier/prettier),
     [`tslint`](https://palantir.github.io/tslint)
+    [`eslint_d`](https://github.com/mantoni/eslint_d.js)
     [`clang-format`](http://clang.llvm.org/docs/ClangFormat.html),
 - VALA
   - [`uncrustify`](http://uncrustify.sourceforge.net)


### PR DESCRIPTION
The `eslint_d` formatter for TypeScript wasn't previously documented. This adds that.