### PR TITLE
docs: capitalize JavaScript, TypeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ that caused Neoformat to be invoked.
 - Java
   - [`uncrustify`](http://uncrustify.sourceforge.net),
     [`astyle`](http://astyle.sourceforge.net)
-- Javascript
+- JavaScript
   - [`js-beautify`](https://github.com/beautify-web/js-beautify),
     [`prettier`](https://github.com/prettier/prettier),
     [`prettydiff`](https://github.com/prettydiff/prettydiff),
@@ -377,7 +377,7 @@ that caused Neoformat to be invoked.
   - [`Swiftformat`](https://github.com/nicklockwood/SwiftFormat)
 - Terraform
   - [`terraform`](https://www.terraform.io/docs/commands/fmt.html),
-- Typescript
+- TypeScript
   - [`tsfmt`](https://github.com/vvakame/typescript-formatter),
     [`prettier`](https://github.com/prettier/prettier),
     [`tslint`](https://palantir.github.io/tslint)

--- a/doc/neoformat.txt
+++ b/doc/neoformat.txt
@@ -275,7 +275,7 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
 - Java
   - [`uncrustify`](http://uncrustify.sourceforge.net),
     [`astyle`](http://astyle.sourceforge.net)
-- Javascript
+- JavaScript
   - [`js-beautify`](https://github.com/beautify-web/js-beautify),
     [`prettier`](https://github.com/jlongster/prettier),
     [`prettydiff`](https://github.com/prettydiff/prettydiff),
@@ -371,7 +371,7 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
   - [`Swiftformat`](https://github.com/nicklockwood/SwiftFormat)
 - Terraform
   - [`terraform`](https://www.terraform.io/docs/commands/fmt.html)
-- Typescript
+- TypeScript
   - [`tsfmt`](https://github.com/vvakame/typescript-formatter),
     [`prettier`](https://github.com/prettier/prettier),
     [`tslint`](https://palantir.github.io/tslint)


### PR DESCRIPTION
[JavaScript](https://www.javascript.com) and [TypeScript](https://www.typescriptlang.org) were previously improperly capitalized.

_edit_: formatting