### PR TITLE
fix tslint formatter when one or more errors couldn't be fixed

### DIFF
--- a/autoload/neoformat/formatters/typescript.vim
+++ b/autoload/neoformat/formatters/typescript.vim
@@ -19,7 +19,7 @@ function! neoformat#formatters#typescript#prettier() abort
 endfunction
 
 function! neoformat#formatters#typescript#tslint() abort
-    let args = ['--fix']
+    let args = ['--fix', '--force']
 
     if filereadable('tslint.json')
         let args = ['-c tslint.json'] + args


### PR DESCRIPTION
Use `--force` to make sure `tslint` always returns status code `0` when exitting.