### PR TITLE
support to affenwiesel/matlab-formatter-vscode

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,8 @@ that caused Neoformat to be invoked.
 - Markdown
   - [`remark`](https://github.com/wooorm/remark)
     [`prettier`](https://github.com/prettier/prettier)
+- Matlab
+  - [`remark`](https://github.com/affenwiesel/matlab-formatter-vscode)
 - Nim
   - `nimpretty` (ships with [`nim`](https://nim-lang.org/))
 - Objective-C

--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ that caused Neoformat to be invoked.
   - [`remark`](https://github.com/wooorm/remark)
     [`prettier`](https://github.com/prettier/prettier)
 - Matlab
-  - [`remark`](https://github.com/affenwiesel/matlab-formatter-vscode)
+  - [`matlab-formatter-vscode`](https://github.com/affenwiesel/matlab-formatter-vscode)
 - Nim
   - `nimpretty` (ships with [`nim`](https://nim-lang.org/))
 - Objective-C

--- a/autoload/neoformat/formatters/matlab.vim
+++ b/autoload/neoformat/formatters/matlab.vim
@@ -1,0 +1,11 @@
+function! neoformat#formatters#matlab#enabled() abort
+    return ['matlabformatter']
+endfunction
+
+function! neoformat#formatters#matlab#matlabformatter() abort
+    return {
+        \ 'exe': 'matlab_formatter.py',
+        \ 'stdin': 0
+        \ }
+endfunction
+

--- a/doc/neoformat.txt
+++ b/doc/neoformat.txt
@@ -303,6 +303,8 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
 - Markdown
   - [`remark`](https://github.com/wooorm/remark)
     [`prettier`](https://github.com/prettier/prettier),
+- Matlab
+  - [`remark`](https://github.com/affenwiesel/matlab-formatter-vscode)
 - Nim
   - nimpretty (ships with [nim](https://nim-lang.org/)),
 - Objective-C

--- a/doc/neoformat.txt
+++ b/doc/neoformat.txt
@@ -304,7 +304,7 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
   - [`remark`](https://github.com/wooorm/remark)
     [`prettier`](https://github.com/prettier/prettier),
 - Matlab
-  - [`remark`](https://github.com/affenwiesel/matlab-formatter-vscode)
+  - [`matlab-formatter-vscode`](https://github.com/affenwiesel/matlab-formatter-vscode)
 - Nim
   - nimpretty (ships with [nim](https://nim-lang.org/)),
 - Objective-C


### PR DESCRIPTION
Hi guys,
this is a small extension to support ```affenwiesel/matlab-formatter-vscode```

However, I couldn't find a proper place to indicate to the end-user that he should add the "formatter" folder of the above repo in the path. 
Any suggestions?