### PR TITLE
[Lua] Add 'lua-fmt'

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ that caused Neoformat to be invoked.
     [`stylelint`](https://stylelint.io/)
 - Lua
   - [`luaformatter`](https://github.com/LuaDevelopmentTools/luaformatter)
+  - [`lua-fmt`](https://github.com/trixnz/lua-fmt)
 - Markdown
   - [`remark`](https://github.com/wooorm/remark)
     [`prettier`](https://github.com/prettier/prettier)

--- a/autoload/neoformat/formatters/lua.vim
+++ b/autoload/neoformat/formatters/lua.vim
@@ -1,9 +1,17 @@
 function! neoformat#formatters#lua#enabled() abort
-    return ['luaformatter']
+    return ['luaformatter', 'luafmt']
 endfunction
 
 function! neoformat#formatters#lua#luaformatter() abort
     return {
         \ 'exe': 'luaformatter'
+        \ }
+endfunction
+
+function! neoformat#formatters#lua#luafmt() abort
+    return {
+        \ 'exe': 'luafmt'
+        \ 'args': ['--stdin'],
+        \ 'stdin': 1,
         \ }
 endfunction


### PR DESCRIPTION
- Add [luafmt](https://github.com/trixnz/lua-fmt) for Lua
- [luaformatter](https://github.com/LuaDevelopmentTools/luaformatter) is inactive and don't support Lua-5.2 or Lua-5.3

Signed-off-by: weiyang <weiyang.ones@gmail.com>