### PR TITLE
Add prettier as svelte formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Or specify a certain formatter (must be defined for the current filetype)
 
 Or format a visual selection of code in a different filetype
 
-__Note:__ you must use a ! and pass the filetype of the selection
+**Note:** you must use a ! and pass the filetype of the selection
 
 ```viml
 :Neoformat! python
@@ -378,6 +378,8 @@ that caused Neoformat to be invoked.
   - [`sqlfmt`](https://github.com/jackc/sqlfmt),
     `sqlformat` (ships with [sqlparse](https://github.com/andialbrecht/sqlparse)),
     `pg_format` (ships with [pgFormatter](https://github.com/darold/pgFormatter))
+- Svelte
+  - [`prettier-plugin-svelte`](https://github.com/UnwrittenFun/prettier-plugin-svelte)
 - Swift
   - [`Swiftformat`](https://github.com/nicklockwood/SwiftFormat)
 - Terraform

--- a/autoload/neoformat/formatters/svelte.vim
+++ b/autoload/neoformat/formatters/svelte.vim
@@ -1,0 +1,11 @@
+function! neoformat#formatters#svelte#enabled() abort
+    return ['prettier']
+endfunction
+
+function! neoformat#formatters#svelte#prettier() abort
+    return {
+        \ 'exe': 'prettier',
+        \ 'args': ['--stdin', '--stdin-filepath', '--parser=svelte', '--plugin-search-dir=.', '"%:p"'],
+        \ 'stdin': 1,
+        \ }
+endfunction

--- a/doc/neoformat.txt
+++ b/doc/neoformat.txt
@@ -371,6 +371,8 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
   - [`sqlfmt`](https://github.com/jackc/sqlfmt)
   - `sqlformat` (ships with [`sqlparse`](https://github.com/andialbrecht/sqlparse))
   - `pg_format` (ships with [`pgFormatter`](https://github.com/darold/pgFormatter))
+- Svelte
+  - [`prettier-plugin-svelte`](https://github.com/UnwrittenFun/prettier-plugin-svelte)
 - Swift
   - [`Swiftformat`](https://github.com/nicklockwood/SwiftFormat)
 - Terraform


### PR DESCRIPTION
Let me know if the README style change should be undone. I blame prettier.

It's technically possible to leave out the `plugin-search-dir` argument if everything is installed globally. But! The svelte compiler is required for the prettier plugin and I don't think most folks install all the svelte compiler globally. This seemed like the most obvious setup.