### PR TITLE
Add a starlark formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,8 @@ that caused Neoformat to be invoked.
   - [`sqlfmt`](https://github.com/jackc/sqlfmt),
     `sqlformat` (ships with [sqlparse](https://github.com/andialbrecht/sqlparse)),
     `pg_format` (ships with [pgFormatter](https://github.com/darold/pgFormatter))
+- Starlark
+  - [`buildifier`](https://github.com/bazelbuild/buildtools/blob/master/buildifier/README.md)
 - Svelte
   - [`prettier-plugin-svelte`](https://github.com/UnwrittenFun/prettier-plugin-svelte)
 - Swift

--- a/autoload/neoformat/formatters/starlark.vim
+++ b/autoload/neoformat/formatters/starlark.vim
@@ -1,0 +1,10 @@
+function! neoformat#formatters#starlark#enabled() abort
+    return ['buildifier']
+endfunction
+
+function! neoformat#formatters#starlark#buildifier() abort
+    return {
+                \ 'exe': 'buildifier',
+                \ 'stdin': 1
+                \ }
+endfunction

--- a/doc/neoformat.txt
+++ b/doc/neoformat.txt
@@ -371,6 +371,8 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
   - [`sqlfmt`](https://github.com/jackc/sqlfmt)
   - `sqlformat` (ships with [`sqlparse`](https://github.com/andialbrecht/sqlparse))
   - `pg_format` (ships with [`pgFormatter`](https://github.com/darold/pgFormatter))
+- Starlark
+  - [`buildifier`](https://github.com/bazelbuild/buildtools/blob/master/buildifier/README.md)
 - Svelte
   - [`prettier-plugin-svelte`](https://github.com/UnwrittenFun/prettier-plugin-svelte)
 - Swift


### PR DESCRIPTION
Simple starlark scripts can reuse the same bazel formatting scripts.