### PR TITLE
Don't format code block headers into attributes

### DIFF
--- a/autoload/neoformat/formatters/pandoc.vim
+++ b/autoload/neoformat/formatters/pandoc.vim
@@ -19,6 +19,7 @@ function! neoformat#formatters#pandoc#pandoc() abort
        \ '-native_spans',
        \ '-simple_tables',
        \ '-multiline_tables',
+       \ '-fenced_code_attributes',
        \ '+emoji',
        \ '+task_lists',
        \ ]


### PR DESCRIPTION
Pandoc currently formats

    ```a

into

    ``` {.a}

which doesn't play well with the rest of Markdown.