### PR TITLE
Added `bsrefmt` formatter to Reason

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,7 @@ that caused Neoformat to be invoked.
     [`formatR`](https://github.com/yihui/formatR)
 - Reason
   - [`refmt`](https://github.com/facebook/reason)
+  - [`bsrefmt`](https://github.com/bucklescript/bucklescript)
 - Ruby
   - [`rufo`](https://github.com/ruby-formatter/rufo),
     [`ruby-beautify`](https://github.com/erniebrodeur/ruby-beautify),

--- a/autoload/neoformat/formatters/reason.vim
+++ b/autoload/neoformat/formatters/reason.vim
@@ -1,10 +1,18 @@
 function! neoformat#formatters#reason#enabled() abort
-    return ['refmt']
+    return ['refmt', 'bsrefmt']
 endfunction
 
 function! neoformat#formatters#reason#refmt() abort
     return {
         \ 'exe': 'refmt',
+        \ 'stdin': 1,
+        \ 'args': ["--interface=" . (expand('%:e') == "rei" ? "true" : "false")],
+        \ }
+endfunction
+
+function! neoformat#formatters#reason#bsrefmt() abort
+    return {
+        \ 'exe': 'bsrefmt',
         \ 'stdin': 1,
         \ 'args': ["--interface=" . (expand('%:e') == "rei" ? "true" : "false")],
         \ }

--- a/doc/neoformat.txt
+++ b/doc/neoformat.txt
@@ -353,6 +353,7 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
     [`formatR`](https://github.com/yihui/formatR)
 - Reason
   - [`refmt`](https://github.com/facebook/reason)
+  - [`bsrefmt`](https://github.com/bucklescript/bucklescript)
 - Ruby
   - [`rufo`](https://github.com/asterite/rufo)
   - [`ruby-beautify`](https://github.com/erniebrodeur/ruby-beautify)


### PR DESCRIPTION
This adds the `bsrefmt` formatter to Reason. This is the perferred formatter for Reason BuckleScript projects according to https://bucklescript.github.io/docs/en/installation