### PR TITLE
go: add gofumpt

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,9 @@ that caused Neoformat to be invoked.
   - [`gleam format`](https://github.com/gleam-lang/gleam/)
 - Go
   - [`gofmt`](https://golang.org/cmd/gofmt/),
-    [`goimports`](https://godoc.org/golang.org/x/tools/cmd/goimports)
+    [`goimports`](https://godoc.org/golang.org/x/tools/cmd/goimports),
+    [`gofumpt`](https://github.com/mvdan/gofumpt),
+    [`gofumports`](https://github.com/mvdan/gofumpt)
 - GLSL
   - [`clang-format`](http://clang.llvm.org/docs/ClangFormat.html)
 - GraphQL

--- a/autoload/neoformat/formatters/go.vim
+++ b/autoload/neoformat/formatters/go.vim
@@ -1,5 +1,5 @@
 function! neoformat#formatters#go#enabled() abort
-   return ['goimports', 'gofmt']
+   return ['goimports', 'gofmt', 'gofumports', 'gofumpt']
 endfunction
 
 function! neoformat#formatters#go#gofmt() abort
@@ -16,3 +16,16 @@ function! neoformat#formatters#go#goimports() abort
             \ }
 endfunction
 
+function! neoformat#formatters#go#gofumpt() abort
+    return {
+            \ 'exe': 'gofumpt',
+            \ 'stdin': 1,
+            \ }
+endfunction
+
+function! neoformat#formatters#go#gofumports() abort
+    return {
+            \ 'exe': 'gofumports',
+            \ 'stdin': 1,
+            \ }
+endfunction

--- a/doc/neoformat.txt
+++ b/doc/neoformat.txt
@@ -259,7 +259,9 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
   - [gleam format](https://github.com/gleam-lang/gleam/)
 - Go
   - [`gofmt`](https://golang.org/cmd/gofmt/),
-    [`goimports`](https://godoc.org/golang.org/x/tools/cmd/goimports)
+    [`goimports`](https://godoc.org/golang.org/x/tools/cmd/goimports),
+    [`gofumpt`](https://github.com/mvdan/gofumpt),
+    [`gofumports`](https://github.com/mvdan/gofumpt)
 - GLSL
   - [`clang-format`](http://clang.llvm.org/docs/ClangFormat.html)
 - GraphQL


### PR DESCRIPTION
Add go formatter [`gofumpt`](https://github.com/mvdan/gofumpt), [`gofumports`](https://github.com/mvdan/gofumpt).
It is stricter format maintained by one of the members of the Go team.

Thanks for the great work by the way!