### PR TITLE
Remove deprecated prettier --stdin option

### DIFF
--- a/autoload/neoformat/formatters/css.vim
+++ b/autoload/neoformat/formatters/css.vim
@@ -40,7 +40,7 @@ endfunction
 function! neoformat#formatters#css#prettier() abort
     return {
         \ 'exe': 'prettier',
-        \ 'args': ['--stdin', '--stdin-filepath', '"%:p"', '--parser', 'css'],
+        \ 'args': ['--stdin-filepath', '"%:p"', '--parser', 'css'],
         \ 'stdin': 1
         \ }
 endfunction

--- a/autoload/neoformat/formatters/graphql.vim
+++ b/autoload/neoformat/formatters/graphql.vim
@@ -5,7 +5,7 @@ endfunction
 function! neoformat#formatters#graphql#prettier() abort
     return {
         \ 'exe': 'prettier',
-        \ 'args': ['--stdin', '--stdin-filepath', '"%:p"', '--parser', 'graphql'],
+        \ 'args': ['--stdin-filepath', '"%:p"', '--parser', 'graphql'],
         \ 'stdin': 1
         \ }
 endfunction

--- a/autoload/neoformat/formatters/html.vim
+++ b/autoload/neoformat/formatters/html.vim
@@ -18,7 +18,7 @@ endfunction
 function! neoformat#formatters#html#prettier() abort
     return {
         \ 'exe': 'prettier',
-        \ 'args': ['--stdin', '--stdin-filepath', '"%:p"'],
+        \ 'args': ['--stdin-filepath', '"%:p"'],
         \ 'stdin': 1,
         \ }
 endfunction

--- a/autoload/neoformat/formatters/java.vim
+++ b/autoload/neoformat/formatters/java.vim
@@ -31,7 +31,7 @@ endfunction
 function! neoformat#formatters#java#prettier() abort
     return {
         \ 'exe': 'prettier',
-        \ 'args': ['--stdin', '--stdin-filepath', '"%:p"'],
+        \ 'args': ['--stdin-filepath', '"%:p"'],
         \ 'stdin': 1,
         \ }
 endfunction

--- a/autoload/neoformat/formatters/javascript.vim
+++ b/autoload/neoformat/formatters/javascript.vim
@@ -40,7 +40,7 @@ endfunction
 function! neoformat#formatters#javascript#prettier() abort
     return {
         \ 'exe': 'prettier',
-        \ 'args': ['--stdin', '--stdin-filepath', '"%:p"'],
+        \ 'args': ['--stdin-filepath', '"%:p"'],
         \ 'stdin': 1,
         \ }
 endfunction

--- a/autoload/neoformat/formatters/json.vim
+++ b/autoload/neoformat/formatters/json.vim
@@ -20,7 +20,7 @@ endfunction
 function! neoformat#formatters#json#prettier() abort
     return {
         \ 'exe': 'prettier',
-        \ 'args': ['--stdin', '--stdin-filepath', '"%:p"', '--parser', 'json'],
+        \ 'args': ['--stdin-filepath', '"%:p"', '--parser', 'json'],
         \ 'stdin': 1,
         \ }
 endfunction

--- a/autoload/neoformat/formatters/kotlin.vim
+++ b/autoload/neoformat/formatters/kotlin.vim
@@ -13,7 +13,7 @@ endfunction
 function! neoformat#formatters#kotlin#prettier() abort
     return {
         \ 'exe': 'prettier',
-        \ 'args': ['--stdin', '--stdin-filepath', '"%:p"'],
+        \ 'args': ['--stdin-filepath', '"%:p"'],
         \ 'stdin': 1,
         \ }
 endfunction

--- a/autoload/neoformat/formatters/markdown.vim
+++ b/autoload/neoformat/formatters/markdown.vim
@@ -5,7 +5,7 @@ endfunction
 function! neoformat#formatters#markdown#prettier() abort
     return {
         \ 'exe': 'prettier',
-        \ 'args': ['--stdin', '--stdin-filepath', '"%:p"'],
+        \ 'args': ['--stdin-filepath', '"%:p"'],
         \ 'stdin': 1,
         \ }
 endfunction

--- a/autoload/neoformat/formatters/svelte.vim
+++ b/autoload/neoformat/formatters/svelte.vim
@@ -5,7 +5,7 @@ endfunction
 function! neoformat#formatters#svelte#prettier() abort
     return {
         \ 'exe': 'prettier',
-        \ 'args': ['--stdin', '--stdin-filepath', '--parser=svelte', '--plugin-search-dir=.', '"%:p"'],
+        \ 'args': ['--stdin-filepath', '--parser=svelte', '--plugin-search-dir=.', '"%:p"'],
         \ 'stdin': 1,
         \ }
 endfunction

--- a/autoload/neoformat/formatters/typescript.vim
+++ b/autoload/neoformat/formatters/typescript.vim
@@ -13,7 +13,7 @@ endfunction
 function! neoformat#formatters#typescript#prettier() abort
     return {
         \ 'exe': 'prettier',
-        \ 'args': ['--stdin', '--stdin-filepath', '"%:p"', '--parser', 'typescript'],
+        \ 'args': ['--stdin-filepath', '"%:p"', '--parser', 'typescript'],
         \ 'stdin': 1
         \ }
 endfunction

--- a/autoload/neoformat/formatters/typescriptreact.vim
+++ b/autoload/neoformat/formatters/typescriptreact.vim
@@ -13,7 +13,7 @@ endfunction
 function! neoformat#formatters#typescriptreact#prettier() abort
     return {
         \ 'exe': 'prettier',
-        \ 'args': ['--stdin', '--stdin-filepath', '"%:p"', '--parser', 'typescript'],
+        \ 'args': ['--stdin-filepath', '"%:p"', '--parser', 'typescript'],
         \ 'stdin': 1
         \ }
 endfunction

--- a/autoload/neoformat/formatters/vue.vim
+++ b/autoload/neoformat/formatters/vue.vim
@@ -5,7 +5,7 @@ endfunction
 function! neoformat#formatters#vue#prettier() abort
     return {
         \ 'exe': 'prettier',
-        \ 'args': ['--stdin', '--stdin-filepath', '"%:p"', '--parser', 'vue'],
+        \ 'args': ['--stdin-filepath', '"%:p"', '--parser', 'vue'],
         \ 'stdin': 1
         \ }
 endfunction

--- a/autoload/neoformat/formatters/xml.vim
+++ b/autoload/neoformat/formatters/xml.vim
@@ -23,7 +23,7 @@ endfunction
 function! neoformat#formatters#xml#prettier() abort
     return {
         \ 'exe': 'prettier',
-        \ 'args': ['--stdin', '--stdin-filepath', '"%:p"'],
+        \ 'args': ['--stdin-filepath', '"%:p"'],
         \ 'stdin': 1,
         \ }
 endfunction

--- a/autoload/neoformat/formatters/yaml.vim
+++ b/autoload/neoformat/formatters/yaml.vim
@@ -13,7 +13,7 @@ endfunction
 function! neoformat#formatters#yaml#prettier() abort
     return {
             \ 'exe': 'prettier',
-            \ 'args': ['--stdin', '--stdin-filepath', '"%:p"', '--parser', 'yaml'],
+            \ 'args': ['--stdin-filepath', '"%:p"', '--parser', 'yaml'],
             \ 'stdin': 1
             \ }
 endfunction


### PR DESCRIPTION
Remove deprecated prettier --stdin option as per https://github.com/prettier/prettier/pull/7668. Resolves #288