### PR TITLE
Fix php-cs-fixer sending blank file to neoformat

### DIFF
--- a/autoload/neoformat/formatters/php.vim
+++ b/autoload/neoformat/formatters/php.vim
@@ -20,6 +20,7 @@ function! neoformat#formatters#php#phpcbf() abort
     return {
            \ 'exe': 'phpcbf',
            \ 'stdin': 1,
+           \ 'args': ['-'],
            \ 'valid_exit_codes': [0,1],
            \ }
 endfunction

--- a/autoload/neoformat/formatters/php.vim
+++ b/autoload/neoformat/formatters/php.vim
@@ -12,6 +12,7 @@ function! neoformat#formatters#php#phpcsfixer() abort
     return {
            \ 'exe': 'php-cs-fixer',
            \ 'args': ['fix', '-q'],
+           \ 'replace': 1,
            \ }
 endfunction
 


### PR DESCRIPTION
Adding the `replace` config setting to the `php-cs-fixer` formatter fixed an issue for me where `php-cs-fixer` was sending a blank file to neoformat's next step (whether it be an additional formatter or the buffer). I'm not quite sure why this was happening, as checking the logs and the temp file that got generated everything seemed fine- so if anyone knows that would be helpful to fix this in a more proper way.

Additionally, I originally thought this was an issue with `phpcbf` since that was the last formatter that got ran and due to the output issue above I was getting the `phpcbf` report saved to my file rather than whatever got formatted. `phpcbf --help` suggests this should be used for `stdin` so I figured it'd be worth adding that while I'm in here.

```
 -     Fix STDIN instead of local files and directories
```