### PR TITLE
Fix R linting with styler

### DIFF
--- a/autoload/neoformat/formatters/r.vim
+++ b/autoload/neoformat/formatters/r.vim
@@ -5,8 +5,8 @@ endfunction
 function! neoformat#formatters#r#styler() abort
     return {
         \ 'exe': 'R',
-        \ 'args': ['--slave', '--no-restore', '--no-save', '-e "styler::style_text(readr::read_file((file(\"stdin\"))))"', '2>/dev/null'],
-        \ 'replace': 1,
+        \ 'args': ['--slave', '--no-restore', '--no-save', '-e "styler::style_text(readr::read_file(file(\"stdin\")))"', '2>/dev/null'],
+        \ 'stdin': 1,
         \}
 endfunction
 


### PR DESCRIPTION
Neoformat's current invocation to lint R with styler expects sending the
buffer data via stdin. The neoformat 'stdin' variable defaults to 0, so
it does not send the file though via stdin. So set `stdin` to 1.

It still does not work though with `replace = 1` so remove it (so it
then inherits the default 0). Now with `stdin = 1` and `replace`
removed, `:Neoformat` works with styler.

While here, remove an excessive pair of parenthesis in the `args` line.