### PR TITLE
Remove stdin and stdout from logged output in verbose mode

### DIFF
--- a/autoload/neoformat.vim
+++ b/autoload/neoformat.vim
@@ -78,7 +78,10 @@ function! s:neoformat(bang, user_input, start_line, end_line) abort
         let stdin = getbufline(bufnr('%'), a:start_line, a:end_line)
         let original_buffer = getbufline(bufnr('%'), 1, '$')
 
-        call neoformat#utils#log(stdin)
+	" include stdin in output only if specified
+        if !neoformat#utils#should_be_compact()
+            call neoformat#utils#log(stdin)
+	endif
 
         call neoformat#utils#log(cmd.exe)
         if cmd.stdin
@@ -96,7 +99,10 @@ function! s:neoformat(bang, user_input, start_line, end_line) abort
             let stdout = readfile(cmd.tmp_file_path)
         endif
 
-        call neoformat#utils#log(stdout)
+	" include stdout in output only if specified
+        if !neoformat#utils#should_be_compact()
+            call neoformat#utils#log(stdout)
+	endif
 
         call neoformat#utils#log(cmd.valid_exit_codes)
         call neoformat#utils#log(v:shell_error)

--- a/autoload/neoformat.vim
+++ b/autoload/neoformat.vim
@@ -108,7 +108,7 @@ function! s:neoformat(bang, user_input, start_line, end_line) abort
         call neoformat#utils#log(v:shell_error)
 
         let process_ran_succesfully = index(cmd.valid_exit_codes, v:shell_error) != -1
-        
+
         if cmd.stderr_log != ''
             call neoformat#utils#log('stderr output redirected to file' . cmd.stderr_log)
             call neoformat#utils#log_file_content(cmd.stderr_log)

--- a/autoload/neoformat/utils.vim
+++ b/autoload/neoformat/utils.vim
@@ -28,6 +28,13 @@ function! neoformat#utils#should_be_verbose() abort
     return &verbose || g:neoformat_verbose
 endfunction
 
+function! neoformat#utils#should_be_compact() abort
+    if !exists('g:neoformat_compact')
+        let g:neoformat_compact = 1
+    endif
+    return g:neoformat_compact
+endfunction
+
 function! s:better_echo(msg) abort
     if type(a:msg) != type('')
         echom 'Neoformat: ' . string(a:msg)


### PR DESCRIPTION
I like to run neoformat in verbose mode for debugging. However, I don't find it so useful having `stdin` and `stdout` logged. 

This PR adds `compact` to the config, so when running with `verbose`, `stdin` and `stdout` only log to the output if `compact==1`. This works for my use-case, so I thought I'd just put this here to see if you all think this would be of interest.