### PR TITLE
Don't reset `&filetype`, unless we really have to

### DIFF
--- a/autoload/neoformat.vim
+++ b/autoload/neoformat.vim
@@ -1,13 +1,18 @@
 function! neoformat#Neoformat(bang, user_input, start_line, end_line) abort
-    let search = @/
     let view = winsaveview()
+    let search = @/
     let original_filetype = &filetype
 
     call s:neoformat(a:bang, a:user_input, a:start_line, a:end_line)
 
+    " Setting &filetype might destroy existing folds, so only do that
+    " if the filetype got changed (which can only be possible when
+    " invoking with a bang)
+    if a:bang && &filetype != original_filetype
+        let &filetype = original_filetype
+    endif
     let @/ = search
     call winrestview(view)
-    let &filetype = original_filetype
 endfunction
 
 function! s:neoformat(bang, user_input, start_line, end_line) abort


### PR DESCRIPTION
Updating `&filetype` (even though we are updating it with its current
value), will force Vim to reload syntax, and potentially folds too.

This changes neoformat implementation to only touch `&filetype` if:

- The user called neoformat with a bang (i.e. to force the formatter for
a different filetype)
- The specified filetype was actually different from the current one

Also, this commit also makes sure settings are restored in the **right**
order (i.e. save A, save B, ..., restore B, restore A).