### PR TITLE
Add 'prettiereslint' as a formatter for 'typescriptreact'

### DIFF
--- a/autoload/neoformat/formatters/typescriptreact.vim
+++ b/autoload/neoformat/formatters/typescriptreact.vim
@@ -1,5 +1,5 @@
 function! neoformat#formatters#typescriptreact#enabled() abort
-   return ['tsfmt', 'prettier', 'tslint', 'eslint_d', 'clangformat', 'denofmt']
+   return ['tsfmt', 'prettier', 'prettiereslint', 'tslint', 'eslint_d', 'clangformat', 'denofmt']
 endfunction
 
 function! neoformat#formatters#typescriptreact#tsfmt() abort
@@ -15,6 +15,14 @@ function! neoformat#formatters#typescriptreact#prettier() abort
         \ 'exe': 'prettier',
         \ 'args': ['--stdin-filepath', '"%:p"', '--parser', 'typescript'],
         \ 'stdin': 1
+        \ }
+endfunction
+
+function! neoformat#formatters#typescriptreact#prettiereslint() abort
+    return {
+        \ 'exe': 'prettier-eslint',
+        \ 'args': ['--stdin', '--stdin-filepath', '"%:p"', '--parser', 'typescript'],
+        \ 'stdin': 1,
         \ }
 endfunction
 


### PR DESCRIPTION
'prettiereslint' is already defined for 'typescript' but wasn't defined for 'typescriptreact'. I wasn't sure if I should also add these changes in `README.md` and `doc/neoformat.txt` since it seems that 'javascriptreact' and 'typescriptreact' are not present.

The function was copied from the definition for 'typescript'