### PR TITLE
Add [biblean](https://github.com/tobywf/bibclean) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,8 @@ that caused Neoformat to be invoked.
   - [`buildifier`](https://github.com/bazelbuild/buildtools/blob/master/buildifier/README.md)
 - Beancount
   - [`bean-format`](https://beancount.github.io/docs/running_beancount_and_generating_reports.html#bean-format)
+- Bib
+  - [bibclean](https://github.com/tobywf/bibclean)
 - C
   - [`uncrustify`](http://uncrustify.sourceforge.net),
     [`clang-format`](http://clang.llvm.org/docs/ClangFormat.html),

--- a/autoload/neoformat/formatters/bib.vim
+++ b/autoload/neoformat/formatters/bib.vim
@@ -1,0 +1,10 @@
+function! neoformat#formatters#bib#enabled() abort
+    return ['bibclean']
+endfunction
+
+function! neoformat#formatters#bib#bibclean() abort
+    return {
+                \ 'exe': 'bibclean',
+                \ 'stdin': 1,
+                \ }
+endfunction

--- a/doc/neoformat.txt
+++ b/doc/neoformat.txt
@@ -216,6 +216,8 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
   - [`buildifier`](https://github.com/bazelbuild/buildtools/blob/master/buildifier/README.md)
 - Beancount
   - [`bean-format`](https://beancount.github.io/docs/running_beancount_and_generating_reports.html#bean-format)
+- Bib
+  - [bibclean](https://github.com/tobywf/bibclean)
 - C
   - [`uncrustify`](http://uncrustify.sourceforge.net),
     [`clang-format`](http://clang.llvm.org/docs/ClangFormat.html),


### PR DESCRIPTION
I needed formatting by bib files and realized it was easy to add support through neoformat. I've followed the procedure described in CONTRIBUTING.md. 

Bib files is a file format for describing references to then be cited in latex documents. Bibclean (https://github.com/tobywf/bibclean) does standard formatting of such files.