### PR TITLE
feat: Add shfmt support for zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,3 +459,8 @@ that caused Neoformat to be invoked.
     [`prettier`](https://github.com/prettier/prettier)
 - zig
   - [`zig fmt`](https://github.com/ziglang/zig)
+- zsh
+  - [`shfmt`](https://github.com/mvdan/sh)
+    ```vim
+    let g:shfmt_opt="-ci"
+    ```

--- a/autoload/neoformat/formatters/zsh.vim
+++ b/autoload/neoformat/formatters/zsh.vim
@@ -1,0 +1,13 @@
+function! neoformat#formatters#zsh#enabled() abort
+    return ['shfmt']
+endfunction
+
+function! neoformat#formatters#zsh#shfmt() abort
+    let opts = get(g:, 'shfmt_opt', '')
+
+    return {
+            \ 'exe': 'shfmt',
+            \ 'args': ['-i ' . shiftwidth(), opts],
+            \ 'stdin': 1,
+            \ }
+endfunction

--- a/doc/neoformat.txt
+++ b/doc/neoformat.txt
@@ -448,6 +448,8 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
     [`prettier`](https://github.com/prettier/prettier)
 - zig
   - [`zig fmt`](https://github.com/ziglang/zig)
+- zsh
+  - [`shfmt`](https://github.com/mvdan/sh)
 
 ==============================================================================
 vim:tw=78:ts=8:ft=help:norl:noet:fen:noet:


### PR DESCRIPTION
Add support for zsh filetype. Verbatim clone of sh.vim except for function names.