### PR TITLE
Add support for rustfmt --config (hard_tabs, max_width and tab_spaces)

### DIFF
--- a/autoload/neoformat/formatters/rust.vim
+++ b/autoload/neoformat/formatters/rust.vim
@@ -5,6 +5,10 @@ endfunction
 function! neoformat#formatters#rust#rustfmt() abort
     return {
         \ 'exe': 'rustfmt',
+        \ 'args': ['--config hard_tabs=' . (&expandtab ? 'false' : 'true') .
+        \                  ',tab_spaces=' . shiftwidth() .
+        \                  ',max_width=' . &textwidth
+        \         ],
         \ 'stdin': 1,
         \ }
 endfunction


### PR DESCRIPTION
This PR adds support for the variables `shiftwidth`, `textwidth` and `expandtab` to format rust files.