### PR TITLE
Remove latexindent option '-sl'

### DIFF
--- a/autoload/neoformat/formatters/tex.vim
+++ b/autoload/neoformat/formatters/tex.vim
@@ -5,7 +5,7 @@ endfunction
 function! neoformat#formatters#tex#latexindent() abort
     return {
         \ 'exe': 'latexindent',
-        \ 'args': ['-sl', '-g /dev/stderr', '2>/dev/null'],
+        \ 'args': ['-g /dev/stderr', '2>/dev/null'],
         \ 'stdin': 1,
         \ }
 endfunction


### PR DESCRIPTION
When using the latest version of `latexindent`, option `-sl` causes the log to be prepended to the formatted file.