### PR TITLE
Add option to trim trailing newline in basic_format

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,9 @@ let g:neoformat_basic_format_retab = 1
 
 " Enable trimmming of trailing whitespace
 let g:neoformat_basic_format_trim = 1
+
+" Enable trimmming of trailing newline
+let g:neoformat_basic_format_trim_newline = 1
 ```
 
 Run all enabled formatters (by default Neoformat stops after the first formatter

--- a/autoload/neoformat.vim
+++ b/autoload/neoformat.vim
@@ -312,6 +312,10 @@ function! s:basic_format() abort
         let g:neoformat_basic_format_trim = 0
     endif
 
+    if !exists('g:neoformat_basic_format_trim_newline')
+        let g:neoformat_basic_format_trim_newline = 0
+    endif
+
     if neoformat#utils#var('neoformat_basic_format_align')
         call neoformat#utils#log('aligning with basic formatter')
         let v = winsaveview()
@@ -329,6 +333,16 @@ function! s:basic_format() abort
         let view = winsaveview()
         " vint: -ProhibitCommandRelyOnUser -ProhibitCommandWithUnintendedSideEffect
         silent! %s/\s\+$//e
+        " vint: +ProhibitCommandRelyOnUser +ProhibitCommandWithUnintendedSideEffect
+        let @/=search
+        call winrestview(view)
+    endif
+    if neoformat#utils#var('neoformat_basic_format_trim_newline')
+        call neoformat#utils#log('trimming newline with basic formatter')
+        let search = @/
+        let view = winsaveview()
+        " vint: -ProhibitCommandRelyOnUser -ProhibitCommandWithUnintendedSideEffect
+        silent! %s/\n\+\%$//e
         " vint: +ProhibitCommandRelyOnUser +ProhibitCommandWithUnintendedSideEffect
         let @/=search
         call winrestview(view)

--- a/doc/neoformat.txt
+++ b/doc/neoformat.txt
@@ -129,6 +129,9 @@ Enable basic formatting when a filetype is not found. Disabled by default.
     " Enable trimmming of trailing whitespace globally
     let g:neoformat_basic_format_trim = 1
 
+    " Enable trimmming of trailing newline globally
+    let g:neoformat_basic_format_trim_newline = 1
+
 Run all enabled formatters (by default Neoformat stops after the first
 formatter succeeds)
 


### PR DESCRIPTION
Similar to neoformat_basic_format_trim but it removes trailing newlines at the end of the file