### PR TITLE
Send buffer data through stdout to cmake-format

### DIFF
--- a/autoload/neoformat/formatters/cmake.vim
+++ b/autoload/neoformat/formatters/cmake.vim
@@ -4,6 +4,8 @@ endfunction
 
 function! neoformat#formatters#cmake#cmakeformat() abort
     return {
-        \ 'exe': 'cmake-format'
+        \ 'exe': 'cmake-format',
+        \ 'args': ['-'],
+        \ 'stdin': 1,
         \ }
 endfunction


### PR DESCRIPTION
Using `/tmp/` prevents cmake-format from picking up `.cmake-format` files, since formatting is done outside the config file tree. Using `stdin` instead solves the issue.