### PR TITLE
feat: add tf formatter for terraform

### DIFF
--- a/autoload/neoformat/formatters/tf.vim
+++ b/autoload/neoformat/formatters/tf.vim
@@ -1,0 +1,11 @@
+function! neoformat#formatters#tf() abort
+   return ['tf']
+endfunction
+
+function! neoformat#formatters#tfm#tf() abort
+    return {
+        \ 'exe': 'terraform',
+        \ 'args': ['fmt', '-write', '-'],
+        \ 'stdin': 1
+        \ }
+endfunction


### PR DESCRIPTION
Newer tools such as `coc.vim` or `lsp` use the `tf` filetype over `terraform`.