### PR TITLE
Revert #335 which forces rustfmt config options in all cases

### DIFF
--- a/autoload/neoformat/formatters/rust.vim
+++ b/autoload/neoformat/formatters/rust.vim
@@ -5,10 +5,6 @@ endfunction
 function! neoformat#formatters#rust#rustfmt() abort
     return {
         \ 'exe': 'rustfmt',
-        \ 'args': ['--config hard_tabs=' . (&expandtab ? 'false' : 'true') .
-        \                  ',tab_spaces=' . shiftwidth() .
-        \                  ',max_width=' . &textwidth
-        \         ],
         \ 'stdin': 1,
         \ }
 endfunction


### PR DESCRIPTION
rustfmt uses .rustfmt.toml in order to configure its options. By default it will traverse the parent directory chain to look for this file, and if it doesn't find it then it will look in the user's home directory or .config/rustfmt. This feature is useful for projects that want to check a .rustfmt.toml into source control so that formatting is consistent across developers editing code in the repository.

The previous diff #335 checked in defaults that override the .rustfmt.toml config. So neoformat will format rust files differently than the .rustfmt.toml in version control specifies that they should be. A better approach than the previous diff would be to create a .rustfmt.toml in the user's dotfiles if there are options that someone always wants to use when formatting rust code.

Source: https://github.com/rust-lang/rustfmt/blob/master/Configurations.md