### PR TITLE
Use node executables in node_modules before $PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,16 +74,17 @@ Define custom formatters.
 
 Options:
 
-| name               | description                                                                                                       | default | optional / required |
-| ------------------ | ----------------------------------------------------------------------------------------------------------------- | ------- | ------------------- |
-| `exe`              | the name the formatter executable in the path                                                                     | n/a     | **required**        |
-| `args`             | list of arguments                                                                                                 | \[]     | optional            |
-| `replace`          | overwrite the file, instead of updating the buffer                                                                | 0       | optional            |
-| `stdin`            | send data to the stdin of the formatter                                                                           | 0       | optional            |
-| `stderr`           | capture stderr output from formatter                                                                              | 0       | optional            |
-| `no_append`        | do not append the `path` of the file to the formatter command, used when the `path` is in the middle of a command | 0       | optional            |
-| `env`              | list of environment variable definitions to be prepended to the formatter command                                 | \[]     | optional            |
-| `valid_exit_codes` | list of valid exit codes for formatters who do not respect common unix practices                                  | \[0]    | optional            |
+| name               | description                                                                                                                                                   | default | optional / required |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | ------------------- |
+| `exe`              | the name the formatter executable in the path                                                                                                                 | n/a     | **required**        |
+| `args`             | list of arguments                                                                                                                                             | \[]     | optional            |
+| `replace`          | overwrite the file, instead of updating the buffer                                                                                                            | 0       | optional            |
+| `stdin`            | send data to the stdin of the formatter                                                                                                                       | 0       | optional            |
+| `stderr`           | capture stderr output from formatter                                                                                                                          | 0       | optional            |
+| `no_append`        | do not append the `path` of the file to the formatter command, used when the `path` is in the middle of a command                                             | 0       | optional            |
+| `env`              | list of environment variable definitions to be prepended to the formatter command                                                                             | \[]     | optional            |
+| `valid_exit_codes` | list of valid exit codes for formatters who do not respect common unix practices                                                                              | \[0]    | optional            |
+| `try_node_exe`     | attempt to find `exe` in a `node_modules/.bin` directory in the current working directory or one of its parents (requires setting `g:neoformat_try_node_exe`) | 0       | optional            |
 
 Example:
 
@@ -153,6 +154,14 @@ When debugging, you can enable either of following variables for extra logging.
 let g:neoformat_verbose = 1 " only affects the verbosity of Neoformat
 " Or
 let &verbose            = 1 " also increases verbosity of the editor as a whole
+```
+
+Have Neoformat look for a formatter executable in the `node_modules/.bin`
+directory in the current working directory or one of its parents (only applies
+to formatters with `try_node_exe` set to `1`):
+
+```viml
+let g:neoformat_try_node_exe = 1
 ```
 
 ## Adding a New Formatter

--- a/autoload/neoformat.vim
+++ b/autoload/neoformat.vim
@@ -220,11 +220,26 @@ function! s:split_filetypes(filetype) abort
     return split(a:filetype, '\.')[0]
 endfunction
 
+function! s:get_node_exe(exe) abort
+    let node_exe = findfile('node_modules/.bin/' . a:exe, getcwd() . ';')
+    if !empty(node_exe) && executable(node_exe)
+        return node_exe
+    endif
+
+    return a:exe
+endfunction
+
 function! s:generate_cmd(definition, filetype) abort
     let executable = get(a:definition, 'exe', '')
     if executable == ''
         call neoformat#utils#log('no exe field in definition')
         return {}
+    endif
+
+    if exists('g:neoformat_try_node_exe')
+                \ && g:neoformat_try_node_exe
+                \ && get(a:definition, 'try_node_exe', 0)
+        let executable = s:get_node_exe(executable)
     endif
 
     if &shell =~ '\v%(powershell|pwsh)'

--- a/autoload/neoformat/formatters/bzl.vim
+++ b/autoload/neoformat/formatters/bzl.vim
@@ -5,6 +5,7 @@ endfunction
 function! neoformat#formatters#bzl#buildifier() abort
     return {
         \ 'exe': 'buildifier',
-        \ 'stdin': 1
+        \ 'stdin': 1,
+        \ 'try_node_exe': 1,
         \ }
 endfunction

--- a/autoload/neoformat/formatters/css.vim
+++ b/autoload/neoformat/formatters/css.vim
@@ -13,7 +13,8 @@ endfunction
 function! neoformat#formatters#css#csscomb() abort
     return {
             \ 'exe': 'csscomb',
-            \ 'replace': 1
+            \ 'replace': 1,
+            \ 'try_node_exe': 1,
             \ }
 endfunction
 
@@ -34,6 +35,7 @@ function! neoformat#formatters#css#stylefmt() abort
     return {
         \ 'exe': 'stylefmt',
         \ 'stdin': 1,
+        \ 'try_node_exe': 1,
         \ }
 endfunction
 
@@ -41,7 +43,8 @@ function! neoformat#formatters#css#prettier() abort
     return {
         \ 'exe': 'prettier',
         \ 'args': ['--stdin-filepath', '"%:p"', '--parser', 'css'],
-        \ 'stdin': 1
+        \ 'stdin': 1,
+        \ 'try_node_exe': 1,
         \ }
 endfunction
 
@@ -50,5 +53,6 @@ function! neoformat#formatters#css#stylelint() abort
             \ 'exe': 'stylelint',
             \ 'args': ['--fix', '--stdin-filename', '"%:t"'],
             \ 'stdin': 1,
+            \ 'try_node_exe': 1,
             \ }
 endfunction

--- a/autoload/neoformat/formatters/elm.vim
+++ b/autoload/neoformat/formatters/elm.vim
@@ -7,5 +7,6 @@ function! neoformat#formatters#elm#elmformat() abort
         \ 'exe': 'elm-format',
         \ 'args': ['--stdin', '--elm-version=0.19'],
         \ 'stdin': 1,
+        \ 'try_node_exe': 1,
         \ }
 endfunction

--- a/autoload/neoformat/formatters/graphql.vim
+++ b/autoload/neoformat/formatters/graphql.vim
@@ -6,6 +6,7 @@ function! neoformat#formatters#graphql#prettier() abort
     return {
         \ 'exe': 'prettier',
         \ 'args': ['--stdin-filepath', '"%:p"', '--parser', 'graphql'],
-        \ 'stdin': 1
+        \ 'stdin': 1,
+        \ 'try_node_exe': 1,
         \ }
 endfunction

--- a/autoload/neoformat/formatters/html.vim
+++ b/autoload/neoformat/formatters/html.vim
@@ -11,7 +11,8 @@ function! neoformat#formatters#html#tidy() abort
         \          '--vertical-space yes',
         \          '--tidy-mark no',
         \          '-wrap ' . &textwidth
-        \         ]
+        \         ],
+        \ 'try_node_exe': 1,
         \ }
 endfunction
 
@@ -20,6 +21,7 @@ function! neoformat#formatters#html#prettier() abort
         \ 'exe': 'prettier',
         \ 'args': ['--stdin-filepath', '"%:p"'],
         \ 'stdin': 1,
+        \ 'try_node_exe': 1,
         \ }
 endfunction
 

--- a/autoload/neoformat/formatters/javascript.vim
+++ b/autoload/neoformat/formatters/javascript.vim
@@ -7,6 +7,7 @@ function! neoformat#formatters#javascript#jsbeautify() abort
             \ 'exe': 'js-beautify',
             \ 'args': ['--indent-size ' .shiftwidth()],
             \ 'stdin': 1,
+            \ 'try_node_exe': 1,
             \ }
 endfunction
 
@@ -14,7 +15,8 @@ function! neoformat#formatters#javascript#clangformat() abort
     return {
             \ 'exe': 'clang-format',
             \ 'args': ['-assume-filename=' . expand('%:t')],
-            \ 'stdin': 1
+            \ 'stdin': 1,
+            \ 'try_node_exe': 1,
             \ }
 endfunction
 
@@ -34,6 +36,7 @@ function! neoformat#formatters#javascript#esformatter() abort
     return {
         \ 'exe': 'esformatter',
         \ 'stdin': 1,
+        \ 'try_node_exe': 1,
         \ }
 endfunction
 
@@ -42,6 +45,7 @@ function! neoformat#formatters#javascript#prettier() abort
         \ 'exe': 'prettier',
         \ 'args': ['--stdin-filepath', '"%:p"'],
         \ 'stdin': 1,
+        \ 'try_node_exe': 1,
         \ }
 endfunction
 
@@ -50,6 +54,7 @@ function! neoformat#formatters#javascript#prettiereslint() abort
         \ 'exe': 'prettier-eslint',
         \ 'args': ['--stdin', '--stdin-filepath', '"%:p"'],
         \ 'stdin': 1,
+        \ 'try_node_exe': 1,
         \ }
 endfunction
 
@@ -58,6 +63,7 @@ function! neoformat#formatters#javascript#eslint_d() abort
         \ 'exe': 'eslint_d',
         \ 'args': ['--stdin', '--stdin-filename', '"%:p"', '--fix-to-stdout'],
         \ 'stdin': 1,
+        \ 'try_node_exe': 1,
         \ }
 endfunction
 
@@ -66,6 +72,7 @@ function! neoformat#formatters#javascript#standard() abort
         \ 'exe': 'standard',
         \ 'args': ['--stdin','--fix'],
         \ 'stdin': 1,
+        \ 'try_node_exe': 1,
         \ }
 endfunction
 
@@ -82,5 +89,6 @@ function! neoformat#formatters#javascript#semistandard() abort
         \ 'exe': 'semistandard',
         \ 'args': ['--stdin','--fix'],
         \ 'stdin': 1,
+        \ 'try_node_exe': 1,
         \ }
 endfunction

--- a/autoload/neoformat/formatters/javascriptreact.vim
+++ b/autoload/neoformat/formatters/javascriptreact.vim
@@ -7,6 +7,7 @@ function! neoformat#formatters#javascriptreact#jsbeautify() abort
             \ 'exe': 'js-beautify',
             \ 'args': ['--indent-size ' .shiftwidth()],
             \ 'stdin': 1,
+            \ 'try_node_exe': 1,
             \ }
 endfunction
 
@@ -26,6 +27,7 @@ function! neoformat#formatters#javascriptreact#esformatter() abort
     return {
         \ 'exe': 'esformatter',
         \ 'stdin': 1,
+        \ 'try_node_exe': 1,
         \ }
 endfunction
 
@@ -34,6 +36,7 @@ function! neoformat#formatters#javascriptreact#prettier() abort
         \ 'exe': 'prettier',
         \ 'args': ['--stdin-filepath', '"%:p"'],
         \ 'stdin': 1,
+        \ 'try_node_exe': 1,
         \ }
 endfunction
 
@@ -42,6 +45,7 @@ function! neoformat#formatters#javascriptreact#prettiereslint() abort
         \ 'exe': 'prettier-eslint',
         \ 'args': ['--stdin', '--stdin-filepath', '"%:p"'],
         \ 'stdin': 1,
+        \ 'try_node_exe': 1,
         \ }
 endfunction
 
@@ -50,6 +54,7 @@ function! neoformat#formatters#javascriptreact#eslint_d() abort
         \ 'exe': 'eslint_d',
         \ 'args': ['--stdin', '--stdin-filename', '"%:p"', '--fix-to-stdout'],
         \ 'stdin': 1,
+        \ 'try_node_exe': 1,
         \ }
 endfunction
 
@@ -58,6 +63,7 @@ function! neoformat#formatters#javascriptreact#standard() abort
         \ 'exe': 'standard',
         \ 'args': ['--stdin','--fix'],
         \ 'stdin': 1,
+        \ 'try_node_exe': 1,
         \ }
 endfunction
 
@@ -74,5 +80,6 @@ function! neoformat#formatters#javascriptreact#semistandard() abort
         \ 'exe': 'semistandard',
         \ 'args': ['--stdin','--fix'],
         \ 'stdin': 1,
+        \ 'try_node_exe': 1,
         \ }
 endfunction

--- a/autoload/neoformat/formatters/json.vim
+++ b/autoload/neoformat/formatters/json.vim
@@ -22,6 +22,7 @@ function! neoformat#formatters#json#prettier() abort
         \ 'exe': 'prettier',
         \ 'args': ['--stdin-filepath', '"%:p"', '--parser', 'json'],
         \ 'stdin': 1,
+        \ 'try_node_exe': 1,
         \ }
 endfunction
 
@@ -31,5 +32,6 @@ function! neoformat#formatters#json#fixjson() abort
         \ 'exe': 'fixjson',
         \ 'args': ['--stdin-filename', l:filename],
         \ 'stdin': 1,
+        \ 'try_node_exe': 1,
         \ }
 endfunction

--- a/autoload/neoformat/formatters/markdown.vim
+++ b/autoload/neoformat/formatters/markdown.vim
@@ -7,6 +7,7 @@ function! neoformat#formatters#markdown#prettier() abort
         \ 'exe': 'prettier',
         \ 'args': ['--stdin-filepath', '"%:p"'],
         \ 'stdin': 1,
+        \ 'try_node_exe': 1,
         \ }
 endfunction
 
@@ -15,5 +16,6 @@ function! neoformat#formatters#markdown#remark() abort
             \ 'exe': 'remark',
             \ 'args': ['--no-color', '--silent'],
             \ 'stdin': 1,
+            \ 'try_node_exe': 1,
             \ }
 endfunction

--- a/autoload/neoformat/formatters/purescript.vim
+++ b/autoload/neoformat/formatters/purescript.vim
@@ -7,6 +7,7 @@ function! neoformat#formatters#purescript#purstidy() abort
         \ 'exe': 'purs-tidy',
         \ 'args': ['format'],
         \ 'stdin': 1,
+        \ 'try_node_exe': 1,
         \ }
 endfunction
 
@@ -15,5 +16,6 @@ function! neoformat#formatters#purescript#purty() abort
         \ 'exe': 'purty',
         \ 'args': ['-'],
         \ 'stdin': 1,
+        \ 'try_node_exe': 1,
         \ }
 endfunction

--- a/autoload/neoformat/formatters/reason.vim
+++ b/autoload/neoformat/formatters/reason.vim
@@ -7,6 +7,7 @@ function! neoformat#formatters#reason#refmt() abort
         \ 'exe': 'refmt',
         \ 'stdin': 1,
         \ 'args': ["--interface=" . (expand('%:e') == "rei" ? "true" : "false")],
+        \ 'try_node_exe': 1,
         \ }
 endfunction
 

--- a/autoload/neoformat/formatters/sass.vim
+++ b/autoload/neoformat/formatters/sass.vim
@@ -7,6 +7,7 @@ function! neoformat#formatters#sass#sassconvert() abort
             \ 'exe': 'sass-convert',
             \ 'args': ['-F sass', '-T sass', '-s'],
             \ 'stdin': 1,
+            \ 'try_node_exe': 1,
             \ }
 endfunction
 

--- a/autoload/neoformat/formatters/scss.vim
+++ b/autoload/neoformat/formatters/scss.vim
@@ -7,6 +7,7 @@ function! neoformat#formatters#scss#sassconvert() abort
             \ 'exe': 'sass-convert',
             \ 'args': ['-F scss', '-T scss', '--indent ' . (&expandtab ? shiftwidth() : 't')],
             \ 'stdin': 1,
+            \ 'try_node_exe': 1,
             \ }
 endfunction
 

--- a/autoload/neoformat/formatters/starlark.vim
+++ b/autoload/neoformat/formatters/starlark.vim
@@ -5,6 +5,7 @@ endfunction
 function! neoformat#formatters#starlark#buildifier() abort
     return {
                 \ 'exe': 'buildifier',
-                \ 'stdin': 1
+                \ 'stdin': 1,
+                \ 'try_node_exe': 1,
                 \ }
 endfunction

--- a/autoload/neoformat/formatters/svelte.vim
+++ b/autoload/neoformat/formatters/svelte.vim
@@ -7,5 +7,6 @@ function! neoformat#formatters#svelte#prettier() abort
         \ 'exe': 'prettier',
         \ 'args': ['--stdin-filepath', '--parser=svelte', '--plugin-search-dir=.', '"%:p"'],
         \ 'stdin': 1,
+        \ 'try_node_exe': 1,
         \ }
 endfunction

--- a/autoload/neoformat/formatters/typescript.vim
+++ b/autoload/neoformat/formatters/typescript.vim
@@ -6,7 +6,8 @@ function! neoformat#formatters#typescript#tsfmt() abort
     return {
         \ 'exe': 'tsfmt',
         \ 'args': ['--replace', '--baseDir=%:h'],
-        \ 'replace': 1
+        \ 'replace': 1,
+        \ 'try_node_exe': 1,
         \ }
 endfunction
 
@@ -14,7 +15,8 @@ function! neoformat#formatters#typescript#prettier() abort
     return {
         \ 'exe': 'prettier',
         \ 'args': ['--stdin-filepath', '"%:p"', '--parser', 'typescript'],
-        \ 'stdin': 1
+        \ 'stdin': 1,
+        \ 'try_node_exe': 1,
         \ }
 endfunction
 
@@ -23,6 +25,7 @@ function! neoformat#formatters#typescript#prettiereslint() abort
         \ 'exe': 'prettier-eslint',
         \ 'args': ['--stdin', '--stdin-filepath', '"%:p"', '--parser', 'typescript'],
         \ 'stdin': 1,
+        \ 'try_node_exe': 1,
         \ }
 endfunction
 
@@ -36,7 +39,8 @@ function! neoformat#formatters#typescript#tslint() abort
     return {
         \ 'exe': 'tslint',
         \ 'args': args,
-        \ 'replace': 1
+        \ 'replace': 1,
+        \ 'try_node_exe': 1,
         \ }
 endfunction
 
@@ -45,6 +49,7 @@ function! neoformat#formatters#typescript#eslint_d() abort
         \ 'exe': 'eslint_d',
         \ 'args': ['--stdin', '--stdin-filename', '"%:p"', '--fix-to-stdout'],
         \ 'stdin': 1,
+        \ 'try_node_exe': 1,
         \ }
 endfunction
 
@@ -52,7 +57,8 @@ function! neoformat#formatters#typescript#clangformat() abort
     return {
             \ 'exe': 'clang-format',
             \ 'args': ['-assume-filename=' . expand('%:t')],
-            \ 'stdin': 1
+            \ 'stdin': 1,
+            \ 'try_node_exe': 1,
             \ }
 endfunction
 

--- a/autoload/neoformat/formatters/typescriptreact.vim
+++ b/autoload/neoformat/formatters/typescriptreact.vim
@@ -6,7 +6,8 @@ function! neoformat#formatters#typescriptreact#tsfmt() abort
     return {
         \ 'exe': 'tsfmt',
         \ 'args': ['--replace', '--baseDir=%:h'],
-        \ 'replace': 1
+        \ 'replace': 1,
+        \ 'try_node_exe': 1,
         \ }
 endfunction
 
@@ -14,7 +15,8 @@ function! neoformat#formatters#typescriptreact#prettier() abort
     return {
         \ 'exe': 'prettier',
         \ 'args': ['--stdin-filepath', '"%:p"', '--parser', 'typescript'],
-        \ 'stdin': 1
+        \ 'stdin': 1,
+        \ 'try_node_exe': 1,
         \ }
 endfunction
 
@@ -23,6 +25,7 @@ function! neoformat#formatters#typescriptreact#prettiereslint() abort
         \ 'exe': 'prettier-eslint',
         \ 'args': ['--stdin', '--stdin-filepath', '"%:p"', '--parser', 'typescript'],
         \ 'stdin': 1,
+        \ 'try_node_exe': 1,
         \ }
 endfunction
 
@@ -36,7 +39,8 @@ function! neoformat#formatters#typescriptreact#tslint() abort
     return {
         \ 'exe': 'tslint',
         \ 'args': args,
-        \ 'replace': 1
+        \ 'replace': 1,
+        \ 'try_node_exe': 1,
         \ }
 endfunction
 
@@ -45,6 +49,7 @@ function! neoformat#formatters#typescriptreact#eslint_d() abort
         \ 'exe': 'eslint_d',
         \ 'args': ['--stdin', '--stdin-filename', '"%:p"', '--fix-to-stdout'],
         \ 'stdin': 1,
+        \ 'try_node_exe': 1,
         \ }
 endfunction
 
@@ -52,7 +57,8 @@ function! neoformat#formatters#typescriptreact#clangformat() abort
     return {
             \ 'exe': 'clang-format',
             \ 'args': ['-assume-filename=' . expand('%:t')],
-            \ 'stdin': 1
+            \ 'stdin': 1,
+            \ 'try_node_exe': 1,
             \ }
 endfunction
 

--- a/autoload/neoformat/formatters/vue.vim
+++ b/autoload/neoformat/formatters/vue.vim
@@ -6,6 +6,7 @@ function! neoformat#formatters#vue#prettier() abort
     return {
         \ 'exe': 'prettier',
         \ 'args': ['--stdin-filepath', '"%:p"', '--parser', 'vue'],
-        \ 'stdin': 1
+        \ 'stdin': 1,
+        \ 'try_node_exe': 1,
         \ }
 endfunction

--- a/autoload/neoformat/formatters/xhtml.vim
+++ b/autoload/neoformat/formatters/xhtml.vim
@@ -13,6 +13,7 @@ function! neoformat#formatters#xhtml#tidy() abort
             \          '--tidy-mark no'
             \         ],
             \ 'stdin': 1,
+            \ 'try_node_exe': 1,
             \ }
 endfunction
 

--- a/autoload/neoformat/formatters/xml.vim
+++ b/autoload/neoformat/formatters/xml.vim
@@ -13,6 +13,7 @@ function! neoformat#formatters#xml#tidy() abort
             \          '--tidy-mark no'
             \         ],
             \ 'stdin': 1,
+            \ 'try_node_exe': 1,
             \ }
 endfunction
 
@@ -25,6 +26,7 @@ function! neoformat#formatters#xml#prettier() abort
         \ 'exe': 'prettier',
         \ 'args': ['--stdin-filepath', '"%:p"'],
         \ 'stdin': 1,
+        \ 'try_node_exe': 1,
         \ }
 endfunction
 

--- a/autoload/neoformat/formatters/yaml.vim
+++ b/autoload/neoformat/formatters/yaml.vim
@@ -14,6 +14,7 @@ function! neoformat#formatters#yaml#prettier() abort
     return {
             \ 'exe': 'prettier',
             \ 'args': ['--stdin-filepath', '"%:p"', '--parser', 'yaml'],
-            \ 'stdin': 1
+            \ 'stdin': 1,
+            \ 'try_node_exe': 1,
             \ }
 endfunction

--- a/doc/neoformat.txt
+++ b/doc/neoformat.txt
@@ -98,6 +98,7 @@ Options:
 | `env`       | list of environment variables to prepend to the command | default: [] | optional
 
 | `valid_exit_codes` | list of valid exit codes for formatters who do not respect common unix practices | \[0] | optional
+| `try_node_exe` | attempt to find `exe` in a `node_modules/.bin` directory in the current working directory or one of its parents (requires setting `g:neoformat_try_node_exe`) | default: 0 | optional
 
 Example:
 
@@ -150,6 +151,13 @@ When debugging, you can enable either of following variables for extra logging.
     " Or
     let &verbose            = 1 " also increases verbosity of the editor as a whole
 <
+Have Neoformat look for a formatter executable in the `node_modules/.bin`
+directory in the current working directory or one of its parents (only applies
+to formatters with `try_node_exe` set to `1`):
+>
+    let g:neoformat_try_node_exe = 1
+<
+
 ==============================================================================
 ADDING A NEW FORMATTER				*neoformat-adding-new-formatter*
 


### PR DESCRIPTION
Many formatters are installed (or can be installed) via `npm`.  When
they are installed for a specific Node project, the executable is placed
in `$project_dir/node_modules/.bin` and is typically *not* on the
`$PATH`.  This change allows Neoformat to look for executables in the
`node_modules/.bin` directory before attempting to use the executable in
the `$PATH`.

For formatters that have `try_node_exe = 1`, and when
`g:neoformat_try_node_exe` is set to `1`, an upward search is performed
beginning at the current directory for `node_modules/.bin/$executable`.
If a match is found, it is used as the executable. If no match is found,
Neoformat will attempt to run the executable as-is.

As part of this change, I set `try_node_exe = 1` on all formatters that
made sense to me -- those related to JS or web development that appeared
to be available via NPM.

Note that this feature is off by default as `g:neoformat_try_node_exe`
must be set before it is used.

Fixes #143.