### PR TITLE
feat: add jsonc support via prettier, remove --parser json option on json

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,8 @@ that caused Neoformat to be invoked.
     [`prettier`](https://github.com/prettier/prettier),
     [`jq`](https://stedolan.github.io/jq/),
     [`fixjson`](https://github.com/rhysd/fixjson)
+- JSONC
+  - [`prettier`](https://github.com/prettier/prettier)
 - Kotlin
   - [`ktlint`](https://github.com/shyiko/ktlint),
     [`prettier`](https://github.com/prettier/prettier)

--- a/README.md
+++ b/README.md
@@ -334,14 +334,14 @@ that caused Neoformat to be invoked.
     [`eslint_d`](https://github.com/mantoni/eslint_d.js),
     [`standard`](https://standardjs.com/),
     [`semistandard`](https://github.com/standard/semistandard),
-    [`deno fmt`](https://deno.land/manual/tools/formatter),
+    [`deno fmt`](https://deno.land/manual/tools/formatter)
 - JSON
   - [`js-beautify`](https://github.com/beautify-web/js-beautify),
     [`prettydiff`](https://github.com/prettydiff/prettydiff),
     [`prettier`](https://github.com/prettier/prettier),
     [`jq`](https://stedolan.github.io/jq/),
     [`fixjson`](https://github.com/rhysd/fixjson)
-- JSONC
+- JSONC (JSON with comments)
   - [`prettier`](https://github.com/prettier/prettier)
 - Kotlin
   - [`ktlint`](https://github.com/shyiko/ktlint),

--- a/autoload/neoformat/formatters/json.vim
+++ b/autoload/neoformat/formatters/json.vim
@@ -20,7 +20,7 @@ endfunction
 function! neoformat#formatters#json#prettier() abort
     return {
         \ 'exe': 'prettier',
-        \ 'args': ['--stdin-filepath', '"%:p"', '--parser', 'json'],
+        \ 'args': ['--stdin-filepath', '"%:p"'],
         \ 'stdin': 1,
         \ 'try_node_exe': 1,
         \ }

--- a/autoload/neoformat/formatters/jsonc.vim
+++ b/autoload/neoformat/formatters/jsonc.vim
@@ -1,0 +1,12 @@
+function! neoformat#formatters#jsonc#enabled() abort
+    return ['prettier']
+endfunction
+
+function! neoformat#formatters#jsonc#prettier() abort
+    return {
+        \ 'exe': 'prettier',
+        \ 'args': ['--stdin-filepath', '"%:p"'],
+        \ 'stdin': 1,
+        \ 'try_node_exe': 1,
+        \ }
+endfunction


### PR DESCRIPTION
- Support `jsonc` so we can do `:Neoformat` on files like `tsconfig.json`
- Remove `--parser json` option since it produces inconsistent format style