### PR TITLE
Specify a file path for buildifier

### DIFF
--- a/autoload/neoformat/formatters/bzl.vim
+++ b/autoload/neoformat/formatters/bzl.vim
@@ -5,6 +5,7 @@ endfunction
 function! neoformat#formatters#bzl#buildifier() abort
     return {
         \ 'exe': 'buildifier',
+        \ 'args': ['-path', expand('%:p')],
         \ 'stdin': 1,
         \ 'try_node_exe': 1,
         \ }

--- a/autoload/neoformat/formatters/starlark.vim
+++ b/autoload/neoformat/formatters/starlark.vim
@@ -4,8 +4,9 @@ endfunction
 
 function! neoformat#formatters#starlark#buildifier() abort
     return {
-                \ 'exe': 'buildifier',
-                \ 'stdin': 1,
-                \ 'try_node_exe': 1,
-                \ }
+        \ 'exe': 'buildifier',
+        \ 'args': ['-path', expand('%:p')],
+        \ 'stdin': 1,
+        \ 'try_node_exe': 1,
+        \ }
 endfunction


### PR DESCRIPTION
buildifier -h says:

> Buildifier's reformatting depends in part on the path to the file relative
> to the workspace directory. Normally buildifier deduces that path from the
> file names given, but the path can be given explicitly with the -path
> argument. This is especially useful when reformatting standard input,
> or in scripts that reformat a temporary copy of a file.

Indeed without -path, it won't format the files properly. Specify it.