### PR TITLE
feat(toml): add basic toml support via taplo

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ The `undojoin` command will put changes made by Neoformat into the same
 [Managing Undo History](#managing-undo-history).
 
 ## Install
+
 The best way to install Neoformat is with your favorite plugin manager for Vim, such as [vim-plug](https://github.com/junegunn/vim-plug):
+
 ```viml
 Plug 'sbdchd/neoformat'
 ```
@@ -309,6 +311,8 @@ that caused Neoformat to be invoked.
     " wrong
     let g:neoformat_enabled_haskell = ['sort-imports', 'stylish-haskell']
     ```
+- Toml
+  - [`taplo`](https://taplo.tamasfe.dev/cli)
 - Puppet
   - [`puppet-lint`](https://github.com/rodjek/puppet-lint)
 - PureScript

--- a/autoload/neoformat/formatters/toml.vim
+++ b/autoload/neoformat/formatters/toml.vim
@@ -1,0 +1,12 @@
+function! neoformat#formatters#toml#enabled() abort
+  return ['taplo']
+endfunction
+
+function! neoformat#formatters#toml#taplo() abort
+  return {
+        \ 'exe': 'taplo',
+        \ 'args': ['fmt', '-'],
+        \ 'stdin': 1,
+        \ 'try_node_exe': 1,
+        \ }
+endfunction

--- a/doc/neoformat.txt
+++ b/doc/neoformat.txt
@@ -443,6 +443,8 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
     [`eslint_d`](https://github.com/mantoni/eslint_d.js)
     [`clang-format`](http://clang.llvm.org/docs/ClangFormat.html),
     [`deno fmt`](https://deno.land/manual/tools/formatter)
+- Toml
+  - [`taplo`](https://taplo.tamasfe.dev/cli)
 - V
   - `v fmt` (ships with [`v`](https://vlang.io))
 - VALA


### PR DESCRIPTION
- [x] Add toml markup formatting support via `node` package `@taplo/cli` or `rust` package `taplo-cli`
- [x] Add official docs link to `README.md` and `neoformat.txt` `Supported Filetypes` section