### PR TITLE
feat: set global flag `g:neoformat`

### DIFF
--- a/autoload/neoformat.vim
+++ b/autoload/neoformat.vim
@@ -1,3 +1,6 @@
+" Set global flag to allow checking in custom user config
+let g:neoformat = 1
+
 function! neoformat#Neoformat(bang, user_input, start_line, end_line) abort
     let view = winsaveview()
     let search = @/


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/19513289/138547974-558764e1-dfab-45b5-a49f-93e55aa53304.png)

## Motivation

I saw some plugin set the flag to let user the plugin is existed or loaded, for me is check is loaded. But now I can only check it is exists via `has_key(plugs, {plug_name})`.

## Fix usage

```vim
if !exists('g:neoformat') | finish | endif
```