### PR TITLE
Add deno fmt for JSON, JSONC, and Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,8 +347,10 @@ that caused Neoformat to be invoked.
     [`prettier`](https://github.com/prettier/prettier),
     [`jq`](https://stedolan.github.io/jq/),
     [`fixjson`](https://github.com/rhysd/fixjson)
+    [`deno fmt`](https://deno.land/manual/tools/formatter)
 - JSONC (JSON with comments)
   - [`prettier`](https://github.com/prettier/prettier)
+    [`deno fmt`](https://deno.land/manual/tools/formatter)
 - Kotlin
   - [`ktlint`](https://github.com/shyiko/ktlint),
     [`prettier`](https://github.com/prettier/prettier)
@@ -367,6 +369,7 @@ that caused Neoformat to be invoked.
 - Markdown
   - [`remark`](https://github.com/wooorm/remark)
     [`prettier`](https://github.com/prettier/prettier)
+    [`deno fmt`](https://deno.land/manual/tools/formatter)
 - Matlab
   - [`matlab-formatter-vscode`](https://github.com/affenwiesel/matlab-formatter-vscode)
 - Nginx

--- a/autoload/neoformat/formatters/json.vim
+++ b/autoload/neoformat/formatters/json.vim
@@ -1,5 +1,5 @@
 function! neoformat#formatters#json#enabled() abort
-    return ['jsbeautify', 'prettydiff', 'prettier', 'jq', 'fixjson']
+    return ['jsbeautify', 'prettydiff', 'prettier', 'jq', 'fixjson', 'denofmt']
 endfunction
 
 function! neoformat#formatters#json#jsbeautify() abort
@@ -33,5 +33,13 @@ function! neoformat#formatters#json#fixjson() abort
         \ 'args': ['--stdin-filename', l:filename],
         \ 'stdin': 1,
         \ 'try_node_exe': 1,
+        \ }
+endfunction
+
+function! neoformat#formatters#json#denofmt() abort
+    return {
+        \ 'exe': 'deno',
+        \ 'args': ['fmt','-'],
+        \ 'stdin': 1,
         \ }
 endfunction

--- a/autoload/neoformat/formatters/jsonc.vim
+++ b/autoload/neoformat/formatters/jsonc.vim
@@ -1,5 +1,5 @@
 function! neoformat#formatters#jsonc#enabled() abort
-    return ['prettier']
+    return ['prettier', 'denofmt']
 endfunction
 
 function! neoformat#formatters#jsonc#prettier() abort
@@ -8,5 +8,13 @@ function! neoformat#formatters#jsonc#prettier() abort
         \ 'args': ['--stdin-filepath', '"%:p"'],
         \ 'stdin': 1,
         \ 'try_node_exe': 1,
+        \ }
+endfunction
+
+function! neoformat#formatters#jsonc#denofmt() abort
+    return {
+        \ 'exe': 'deno',
+        \ 'args': ['fmt','-'],
+        \ 'stdin': 1,
         \ }
 endfunction

--- a/autoload/neoformat/formatters/markdown.vim
+++ b/autoload/neoformat/formatters/markdown.vim
@@ -1,5 +1,5 @@
 function! neoformat#formatters#markdown#enabled() abort
-   return ['remark', 'prettier']
+   return ['remark', 'prettier', 'denofmt']
 endfunction
 
 function! neoformat#formatters#markdown#prettier() abort
@@ -18,4 +18,12 @@ function! neoformat#formatters#markdown#remark() abort
             \ 'stdin': 1,
             \ 'try_node_exe': 1,
             \ }
+endfunction
+
+function! neoformat#formatters#markdown#denofmt() abort
+    return {
+        \ 'exe': 'deno',
+        \ 'args': ['fmt','-'],
+        \ 'stdin': 1,
+        \ }
 endfunction

--- a/doc/neoformat.txt
+++ b/doc/neoformat.txt
@@ -336,6 +336,7 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
     [`prettier`](https://github.com/prettier/prettier),
     [`jq`](https://stedolan.github.io/jq/),
     [`fixjson`](https://github.com/rhysd/fixjson)
+    [`deno fmt`](https://deno.land/manual/tools/formatter)
 - Kotlin
   - [`ktlint`](https://github.com/shyiko/ktlint)
     [`prettier`](https://github.com/prettier/prettier)
@@ -354,6 +355,7 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
 - Markdown
   - [`remark`](https://github.com/wooorm/remark)
     [`prettier`](https://github.com/prettier/prettier),
+    [`deno fmt`](https://deno.land/manual/tools/formatter)
 - Matlab
   - [`matlab-formatter-vscode`](https://github.com/affenwiesel/matlab-formatter-vscode)
 - Nginx


### PR DESCRIPTION
Hi, thank you for the great project.
deno fmt can process not only javascript and typescript but also markdown and json.
This pull request adds deno fmt for these file types.

Thanks.