### PR TITLE
Try to use formatters for subfiletypes

### DIFF
--- a/doc/neoformat.txt
+++ b/doc/neoformat.txt
@@ -135,11 +135,19 @@ formatter succeeds)
 
     let g:neoformat_run_all_formatters = 1
 
+Search for formatter definitions for all subfiletypes (by default Neoformat
+searches only for the first subfiletype, e.g. `typescript` if `filetype`
+is `typescript.jsx`)
+
+    let g:neoformat_all_subfiletypes_formatters = 1
+
 Above options can be activated or deactivated per buffer. For example:
 
-    " runs all formatters for current buffer without tab to spaces conversion
+    " runs all formatters for all subfitypes for current buffer without tab to
+    " spaces conversion
     let b:neoformat_run_all_formatters = 1
     let b:neoformat_basic_format_retab = 0
+    let b:neoformat_all_subfiletypes_formatters = 1
 
 Have Neoformat only msg when there is an error
 >


### PR DESCRIPTION
This adds support for multiple filetypes e.g. `vimwiki.markdown`. Currently neoformat only tries first filetype, which is problematic because as far I'm concerned, it's not possible to configure neoformat to use e.g. `markdown` `prettier` formatter for `vimwiki`. Not even `:Neoformat prettier` would work, because neoformat then searched `prettier` formatter definition for `vimwiki` which doesn't exist.

I only changed code for formatting, and didn't touch code for formatter autocompletion. I could search for all filetypes, but then there is problem to decide which formatter definition to use. We can assume that first definition within filetype should be used. So if I my `&filetype=vimwiki.markdown`, and I run `:Neoformat prettier`, code should try to find `prettier` for `vimwiki`, and then for `markdown`, and so on. For now, I left current behaviour, i.e. first filetype is used, in my example that would be `vimwiki`. and `:Neoformat prettier` would fail to find formatter.

I will mention this in docs when we will agree if that's fine. Also possibly this change should be configurable with global variable, I can add this if requested.