### PR TITLE
Fixed the order of arguments for Prettier with svelte

### DIFF
--- a/autoload/neoformat/formatters/svelte.vim
+++ b/autoload/neoformat/formatters/svelte.vim
@@ -5,7 +5,7 @@ endfunction
 function! neoformat#formatters#svelte#prettier() abort
     return {
         \ 'exe': 'prettier',
-        \ 'args': ['--stdin-filepath', '--parser=svelte', '--plugin-search-dir=.', '"%:p"'],
+        \ 'args': ['--stdin-filepath', '"%:p"', '--parser=svelte', '--plugin-search-dir=.'],
         \ 'stdin': 1,
         \ 'try_node_exe': 1,
         \ }


### PR DESCRIPTION
See #375. When making changes and then saving an unsaved buffer (like one would do with a BufWritePre autocmd to format on save) on a Svelte file the changes that haven't yet been saved get undone.

I noticed the Svelte formatter used a different order of prettier arguments than all of the other formatters that use prettier. The `--stdin-filepath` argument had a couple other arguments before the file path. I reordered them so the file path immediately follows `--stdin-filepath` and that seems to have fixed the issue for me.

I'm pretty sure what's happening is that Prettier ignores the buffer passed as stdin because it doesn't see the file path in the arguments as the value to `--stdin-filepath`, but instead as the file path to the file to format, so it just ignores the buffer text sent over stdin and loads the file from the filesystem which naturally won't have the buffer's changes as they haven't been saved yet. (You can see this by running the commands in the two different orders with `--loglevel debug` to see what it interpreted the cli arguments as.)

The current order is doing something like this:
![image](https://user-images.githubusercontent.com/3468630/139522331-e805670f-bf0e-488a-a3e5-6d0232d8696a.png)

The changed order is doing something like this:
![image](https://user-images.githubusercontent.com/3468630/139522352-74da6539-c4bd-4812-b9b0-e64fcb545b3d.png)
