### PR TITLE
add shfmt fromatter for ebuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,11 @@ that caused Neoformat to be invoked.
   - [`dhall format`](https://dhall-lang.org)
 - dune
   - [`dune format`](https://github.com/ocaml/dune)
+- Ebuild
+  - [`shfmt`](https://github.com/mvdan/sh)
+    ```vim
+    let g:shfmt_opt="-ci"
+    ```
 - Elixir
   - [`mix format`](https://hexdocs.pm/mix/master/Mix.Tasks.Format.html)
 - Elm

--- a/autoload/neoformat/formatters/ebuild.vim
+++ b/autoload/neoformat/formatters/ebuild.vim
@@ -1,0 +1,13 @@
+function! neoformat#formatters#ebuild#enabled() abort
+    return ['shfmt']
+endfunction
+
+function! neoformat#formatters#ebuild#shfmt() abort
+    let opts = get(g:, 'shfmt_opt', '')
+
+    return {
+            \ 'exe': 'shfmt',
+            \ 'args': ['-i ' . (&expandtab ? shiftwidth() : 0), opts],
+            \ 'stdin': 1,
+            \ }
+endfunction


### PR DESCRIPTION
[ebuild](https://wiki.gentoo.org/wiki/Ebuild) is like bash script but with minor differences, and `shfmt` can correctly format it
