### PR TITLE
Add prettierd

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ that caused Neoformat to be invoked.
     [`stylefmt`](https://github.com/morishitter/stylefmt),
     [`stylelint`](https://stylelint.io/),
     [`csscomb`](http://csscomb.com),
+    [`prettierd`](https://github.com/fsouza/prettierd),
     [`prettier`](https://github.com/prettier/prettier)
 - CSV
   - [`prettydiff`](https://github.com/prettydiff/prettydiff)
@@ -299,6 +300,7 @@ that caused Neoformat to be invoked.
 - GLSL
   - [`clang-format`](http://clang.llvm.org/docs/ClangFormat.html)
 - GraphQL
+    [`prettierd`](https://github.com/fsouza/prettierd),
   - [`prettier`](https://github.com/prettier/prettier)
 - Haskell
   - [`stylishhaskell`](https://github.com/jaspervdj/stylish-haskell),
@@ -327,6 +329,7 @@ that caused Neoformat to be invoked.
   - [`purty`](https://gitlab.com/joneshf/purty)
 - HTML
   - `html-beautify` (ships with [`js-beautify`](https://github.com/beautify-web/js-beautify)),
+    [`prettierd`](https://github.com/fsouza/prettierd),
     [`prettier`](https://github.com/prettier/prettier),
     [`prettydiff`](https://github.com/prettydiff/prettydiff)
 - Jade
@@ -334,9 +337,11 @@ that caused Neoformat to be invoked.
 - Java
   - [`uncrustify`](http://uncrustify.sourceforge.net),
     [`astyle`](http://astyle.sourceforge.net),
+    [`prettierd`](https://github.com/fsouza/prettierd),
     [`prettier`](https://github.com/prettier/prettier)
 - JavaScript
   - [`js-beautify`](https://github.com/beautify-web/js-beautify),
+    [`prettierd`](https://github.com/fsouza/prettierd),
     [`prettier`](https://github.com/prettier/prettier),
     [`prettydiff`](https://github.com/prettydiff/prettydiff),
     [`clang-format`](http://clang.llvm.org/docs/ClangFormat.html),
@@ -349,21 +354,25 @@ that caused Neoformat to be invoked.
 - JSON
   - [`js-beautify`](https://github.com/beautify-web/js-beautify),
     [`prettydiff`](https://github.com/prettydiff/prettydiff),
+    [`prettierd`](https://github.com/fsouza/prettierd),
     [`prettier`](https://github.com/prettier/prettier),
     [`jq`](https://stedolan.github.io/jq/),
     [`fixjson`](https://github.com/rhysd/fixjson)
     [`deno fmt`](https://deno.land/manual/tools/formatter)
 - JSONC (JSON with comments)
-  - [`prettier`](https://github.com/prettier/prettier)
+  - [`prettierd`](https://github.com/fsouza/prettierd),
+    [`prettier`](https://github.com/prettier/prettier),
     [`deno fmt`](https://deno.land/manual/tools/formatter)
 - Kotlin
   - [`ktlint`](https://github.com/shyiko/ktlint),
+    [`prettierd`](https://github.com/fsouza/prettierd),
     [`prettier`](https://github.com/prettier/prettier)
 - LaTeX
   - [`latexindent`](https://github.com/cmhughes/latexindent.pl)
 - Less
   - [`csscomb`](http://csscomb.com),
     [`prettydiff`](https://github.com/prettydiff/prettydiff),
+    [`prettierd`](https://github.com/fsouza/prettierd),
     [`prettier`](https://github.com/prettier/prettier),
     [`stylelint`](https://stylelint.io/)
 - Lua
@@ -372,8 +381,9 @@ that caused Neoformat to be invoked.
   - [`lua-format`](https://github.com/Koihik/LuaFormatter)
   - [`stylua`](https://github.com/JohnnyMorganz/StyLua)
 - Markdown
-  - [`remark`](https://github.com/wooorm/remark)
-    [`prettier`](https://github.com/prettier/prettier)
+  - [`remark`](https://github.com/wooorm/remark),
+    [`prettierd`](https://github.com/fsouza/prettierd),
+    [`prettier`](https://github.com/prettier/prettier),
     [`deno fmt`](https://deno.land/manual/tools/formatter)
 - Matlab
   - [`matlab-formatter-vscode`](https://github.com/affenwiesel/matlab-formatter-vscode)
@@ -401,6 +411,7 @@ that caused Neoformat to be invoked.
   - [`php_beautifier`](http://pear.php.net/package/PHP_Beautifier),
     [`php-cs-fixer`](http://cs.sensiolabs.org/),
     [`phpcbf`](https://github.com/squizlabs/PHP_CodeSniffer),
+    [`prettierd`](https://github.com/fsouza/prettierd),
     [`prettier`](https://github.com/prettier/plugin-php)
 - PowerShell
   - [`PSScriptAnalyzer`](https://github.com/PowerShell/PSScriptAnalyzer),
@@ -444,6 +455,7 @@ that caused Neoformat to be invoked.
     [`stylefmt`](https://github.com/morishitter/stylefmt),
     [`prettydiff`](https://github.com/prettydiff/prettydiff),
     [`csscomb`](http://csscomb.com),
+    [`prettierd`](https://github.com/fsouza/prettierd),
     [`prettier`](https://github.com/prettier/prettier)
 - Shell
   - [`shfmt`](https://github.com/mvdan/sh)
@@ -451,7 +463,8 @@ that caused Neoformat to be invoked.
     let g:shfmt_opt="-ci"
     ```
 - Solidity
-  - [`prettier`](https://github.com/prettier-solidity/prettier-plugin-solidity)
+  - [`prettierd`](https://github.com/fsouza/prettierd),
+    [`prettier`](https://github.com/prettier-solidity/prettier-plugin-solidity)
 - SQL
   - [`sqlfmt`](https://github.com/jackc/sqlfmt),
     `sqlformat` (ships with [sqlparse](https://github.com/andialbrecht/sqlparse)),
@@ -461,13 +474,15 @@ that caused Neoformat to be invoked.
 - SugarSS
     [`stylelint`](https://stylelint.io/)
 - Svelte
-  - [`prettier-plugin-svelte`](https://github.com/UnwrittenFun/prettier-plugin-svelte)
+  - [`prettierd`](https://github.com/fsouza/prettierd),
+    [`prettier-plugin-svelte`](https://github.com/UnwrittenFun/prettier-plugin-svelte)
 - Swift
   - [`Swiftformat`](https://github.com/nicklockwood/SwiftFormat)
 - Terraform
   - [`terraform`](https://www.terraform.io/docs/commands/fmt.html),
 - TypeScript
   - [`tsfmt`](https://github.com/vvakame/typescript-formatter),
+    [`prettierd`](https://github.com/fsouza/prettierd),
     [`prettier`](https://github.com/prettier/prettier),
     [`prettier-eslint`](https://github.com/kentcdodds/prettier-eslint-cli),
     [`tslint`](https://palantir.github.io/tslint),
@@ -479,16 +494,19 @@ that caused Neoformat to be invoked.
 - VALA
   - [`uncrustify`](http://uncrustify.sourceforge.net)
 - Vue
-  - [`prettier`](https://github.com/prettier/prettier)
+  - [`prettierd`](https://github.com/fsouza/prettierd),
+    [`prettier`](https://github.com/prettier/prettier)
 - XHTML
   - [`tidy`](http://www.html-tidy.org),
     [`prettydiff`](https://github.com/prettydiff/prettydiff)
 - XML
   - [`tidy`](http://www.html-tidy.org),
     [`prettydiff`](https://github.com/prettydiff/prettydiff),
+    [`prettierd`](https://github.com/fsouza/prettierd),
     [`prettier`](https://github.com/prettier/prettier)
 - YAML
   - [`pyaml`](https://pypi.python.org/pypi/pyaml),
+    [`prettierd`](https://github.com/fsouza/prettierd),
     [`prettier`](https://github.com/prettier/prettier)
 - zig
   - [`zig fmt`](https://github.com/ziglang/zig)

--- a/autoload/neoformat/formatters/css.vim
+++ b/autoload/neoformat/formatters/css.vim
@@ -1,5 +1,5 @@
 function! neoformat#formatters#css#enabled() abort
-    return ['stylelint', 'stylefmt', 'prettier', 'cssbeautify', 'prettydiff', 'csscomb']
+    return ['stylelint', 'stylefmt', 'prettierd', 'prettier', 'cssbeautify', 'prettydiff', 'csscomb']
 endfunction
 
 function! neoformat#formatters#css#cssbeautify() abort
@@ -45,6 +45,14 @@ function! neoformat#formatters#css#prettier() abort
         \ 'args': ['--stdin-filepath', '"%:p"', '--parser', 'css'],
         \ 'stdin': 1,
         \ 'try_node_exe': 1,
+        \ }
+endfunction
+
+function! neoformat#formatters#css#prettierd() abort
+    return {
+        \ 'exe': 'prettierd',
+        \ 'args': ['"%:p"'],
+        \ 'stdin': 1,
         \ }
 endfunction
 

--- a/autoload/neoformat/formatters/graphql.vim
+++ b/autoload/neoformat/formatters/graphql.vim
@@ -1,5 +1,5 @@
 function! neoformat#formatters#graphql#enabled() abort
-    return ['prettier']
+    return ['prettierd', 'prettier']
 endfunction
 
 function! neoformat#formatters#graphql#prettier() abort
@@ -8,5 +8,13 @@ function! neoformat#formatters#graphql#prettier() abort
         \ 'args': ['--stdin-filepath', '"%:p"', '--parser', 'graphql'],
         \ 'stdin': 1,
         \ 'try_node_exe': 1,
+        \ }
+endfunction
+
+function! neoformat#formatters#graphql#prettierd() abort
+    return {
+        \ 'exe': 'prettierd',
+        \ 'args': ['"%:p"'],
+        \ 'stdin': 1,
         \ }
 endfunction

--- a/autoload/neoformat/formatters/html.vim
+++ b/autoload/neoformat/formatters/html.vim
@@ -1,5 +1,5 @@
 function! neoformat#formatters#html#enabled() abort
-    return ['htmlbeautify', 'prettier', 'tidy', 'prettydiff']
+    return ['htmlbeautify', 'prettierd', 'prettier', 'tidy', 'prettydiff']
 endfunction
 
 function! neoformat#formatters#html#tidy() abort
@@ -22,6 +22,14 @@ function! neoformat#formatters#html#prettier() abort
         \ 'args': ['--stdin-filepath', '"%:p"'],
         \ 'stdin': 1,
         \ 'try_node_exe': 1,
+        \ }
+endfunction
+
+function! neoformat#formatters#html#prettierd() abort
+    return {
+        \ 'exe': 'prettierd',
+        \ 'args': ['"%:p"'],
+        \ 'stdin': 1,
         \ }
 endfunction
 

--- a/autoload/neoformat/formatters/java.vim
+++ b/autoload/neoformat/formatters/java.vim
@@ -1,5 +1,5 @@
 function! neoformat#formatters#java#enabled() abort
-   return ['uncrustify', 'astyle', 'clangformat', 'prettier']
+   return ['uncrustify', 'astyle', 'clangformat', 'prettierd', 'prettier']
 endfunction
 
 function! neoformat#formatters#java#uncrustify() abort
@@ -36,4 +36,10 @@ function! neoformat#formatters#java#prettier() abort
         \ }
 endfunction
 
-
+function! neoformat#formatters#java#prettierd() abort
+    return {
+        \ 'exe': 'prettierd',
+        \ 'args': ['"%:p"'],
+        \ 'stdin': 1,
+        \ }
+endfunction

--- a/autoload/neoformat/formatters/javascript.vim
+++ b/autoload/neoformat/formatters/javascript.vim
@@ -1,5 +1,5 @@
 function! neoformat#formatters#javascript#enabled() abort
-    return ['jsbeautify', 'standard', 'semistandard', 'prettier', 'prettydiff', 'clangformat', 'esformatter', 'prettiereslint', 'eslint_d', 'denofmt']
+    return ['jsbeautify', 'standard', 'semistandard', 'prettierd', 'prettier', 'prettydiff', 'clangformat', 'esformatter', 'prettiereslint', 'eslint_d', 'denofmt']
 endfunction
 
 function! neoformat#formatters#javascript#jsbeautify() abort
@@ -46,6 +46,14 @@ function! neoformat#formatters#javascript#prettier() abort
         \ 'args': ['--stdin-filepath', '"%:p"'],
         \ 'stdin': 1,
         \ 'try_node_exe': 1,
+        \ }
+endfunction
+
+function! neoformat#formatters#javascript#prettierd() abort
+    return {
+        \ 'exe': 'prettierd',
+        \ 'args': ['"%:p"'],
+        \ 'stdin': 1,
         \ }
 endfunction
 

--- a/autoload/neoformat/formatters/javascriptreact.vim
+++ b/autoload/neoformat/formatters/javascriptreact.vim
@@ -1,5 +1,5 @@
 function! neoformat#formatters#javascriptreact#enabled() abort
-    return ['jsbeautify', 'standard', 'semistandard', 'prettier', 'prettydiff', 'esformatter', 'prettiereslint', 'eslint_d', 'denofmt']
+    return ['jsbeautify', 'standard', 'semistandard', 'prettierd', 'prettier', 'prettydiff', 'esformatter', 'prettiereslint', 'eslint_d', 'denofmt']
 endfunction
 
 function! neoformat#formatters#javascriptreact#jsbeautify() abort
@@ -37,6 +37,14 @@ function! neoformat#formatters#javascriptreact#prettier() abort
         \ 'args': ['--stdin-filepath', '"%:p"'],
         \ 'stdin': 1,
         \ 'try_node_exe': 1,
+        \ }
+endfunction
+
+function! neoformat#formatters#javascriptreact#prettierd() abort
+    return {
+        \ 'exe': 'prettierd',
+        \ 'args': ['"%:p"'],
+        \ 'stdin': 1,
         \ }
 endfunction
 

--- a/autoload/neoformat/formatters/json.vim
+++ b/autoload/neoformat/formatters/json.vim
@@ -1,5 +1,5 @@
 function! neoformat#formatters#json#enabled() abort
-    return ['jsbeautify', 'prettydiff', 'prettier', 'jq', 'fixjson', 'denofmt']
+    return ['jsbeautify', 'prettydiff', 'prettierd', 'prettier', 'jq', 'fixjson', 'denofmt']
 endfunction
 
 function! neoformat#formatters#json#jsbeautify() abort
@@ -23,6 +23,14 @@ function! neoformat#formatters#json#prettier() abort
         \ 'args': ['--stdin-filepath', '"%:p"'],
         \ 'stdin': 1,
         \ 'try_node_exe': 1,
+        \ }
+endfunction
+
+function! neoformat#formatters#json#prettierd() abort
+    return {
+        \ 'exe': 'prettierd',
+        \ 'args': ['"%:p"'],
+        \ 'stdin': 1,
         \ }
 endfunction
 

--- a/autoload/neoformat/formatters/jsonc.vim
+++ b/autoload/neoformat/formatters/jsonc.vim
@@ -1,5 +1,5 @@
 function! neoformat#formatters#jsonc#enabled() abort
-    return ['prettier', 'denofmt']
+    return ['prettierd', 'prettier', 'denofmt']
 endfunction
 
 function! neoformat#formatters#jsonc#prettier() abort
@@ -8,6 +8,14 @@ function! neoformat#formatters#jsonc#prettier() abort
         \ 'args': ['--stdin-filepath', '"%:p"'],
         \ 'stdin': 1,
         \ 'try_node_exe': 1,
+        \ }
+endfunction
+
+function! neoformat#formatters#jsonc#prettierd() abort
+    return {
+        \ 'exe': 'prettierd',
+        \ 'args': ['"%:p"'],
+        \ 'stdin': 1,
         \ }
 endfunction
 

--- a/autoload/neoformat/formatters/kotlin.vim
+++ b/autoload/neoformat/formatters/kotlin.vim
@@ -1,5 +1,5 @@
 function! neoformat#formatters#kotlin#enabled() abort
-    return ['ktlint', 'prettier']
+    return ['ktlint', 'prettierd', 'prettier']
 endfunction
 
 function! neoformat#formatters#kotlin#ktlint() abort
@@ -18,4 +18,10 @@ function! neoformat#formatters#kotlin#prettier() abort
         \ }
 endfunction
 
-
+function! neoformat#formatters#kotlin#prettierd() abort
+    return {
+        \ 'exe': 'prettierd',
+        \ 'args': ['"%:p"'],
+        \ 'stdin': 1,
+        \ }
+endfunction

--- a/autoload/neoformat/formatters/less.vim
+++ b/autoload/neoformat/formatters/less.vim
@@ -1,5 +1,5 @@
 function! neoformat#formatters#less#enabled() abort
-    return ['stylelint', 'prettier', 'csscomb', 'prettydiff']
+    return ['stylelint', 'prettierd', 'prettier', 'csscomb', 'prettydiff']
 endfunction
 
 function! neoformat#formatters#less#csscomb() abort
@@ -12,6 +12,10 @@ endfunction
 
 function! neoformat#formatters#less#prettier() abort
     return neoformat#formatters#css#prettier()
+endfunction
+
+function! neoformat#formatters#less#prettierd() abort
+    return neoformat#formatters#css#prettierd()
 endfunction
 
 function! neoformat#formatters#less#stylelint() abort

--- a/autoload/neoformat/formatters/markdown.vim
+++ b/autoload/neoformat/formatters/markdown.vim
@@ -1,5 +1,5 @@
 function! neoformat#formatters#markdown#enabled() abort
-   return ['remark', 'prettier', 'denofmt']
+   return ['remark', 'prettierd', 'prettier', 'denofmt']
 endfunction
 
 function! neoformat#formatters#markdown#prettier() abort
@@ -8,6 +8,14 @@ function! neoformat#formatters#markdown#prettier() abort
         \ 'args': ['--stdin-filepath', '"%:p"'],
         \ 'stdin': 1,
         \ 'try_node_exe': 1,
+        \ }
+endfunction
+
+function! neoformat#formatters#markdown#prettierd() abort
+    return {
+        \ 'exe': 'prettierd',
+        \ 'args': ['"%:p"'],
+        \ 'stdin': 1,
         \ }
 endfunction
 

--- a/autoload/neoformat/formatters/php.vim
+++ b/autoload/neoformat/formatters/php.vim
@@ -1,5 +1,5 @@
 function! neoformat#formatters#php#enabled() abort
-    return ['phpbeautifier', 'phpcsfixer', 'phpcbf', 'prettier']
+    return ['phpbeautifier', 'phpcsfixer', 'phpcbf', 'prettierd', 'prettier']
 endfunction
 
 function! neoformat#formatters#php#phpbeautifier() abort
@@ -31,5 +31,13 @@ function! neoformat#formatters#php#prettier() abort
         \ 'args': ['--stdin-filepath', '"%:p"'],
         \ 'stdin': 1,
         \ 'try_node_exe': 1,
+        \ }
+endfunction
+
+function! neoformat#formatters#php#prettierd() abort
+    return {
+        \ 'exe': 'prettierd',
+        \ 'args': ['"%:p"'],
+        \ 'stdin': 1,
         \ }
 endfunction

--- a/autoload/neoformat/formatters/scss.vim
+++ b/autoload/neoformat/formatters/scss.vim
@@ -1,5 +1,5 @@
 function! neoformat#formatters#scss#enabled() abort
-   return ['sassconvert', 'stylelint', 'stylefmt', 'prettier', 'prettydiff', 'csscomb']
+   return ['sassconvert', 'stylelint', 'stylefmt', 'prettierd', 'prettier', 'prettydiff', 'csscomb']
 endfunction
 
 function! neoformat#formatters#scss#sassconvert() abort
@@ -25,6 +25,10 @@ endfunction
 
 function! neoformat#formatters#scss#prettier() abort
     return neoformat#formatters#css#prettier()
+endfunction
+
+function! neoformat#formatters#scss#prettierd() abort
+    return neoformat#formatters#css#prettierd()
 endfunction
 
 function! neoformat#formatters#scss#stylelint() abort

--- a/autoload/neoformat/formatters/solidity.vim
+++ b/autoload/neoformat/formatters/solidity.vim
@@ -1,5 +1,5 @@
 function! neoformat#formatters#solidity#enabled() abort
-    return ['prettier']
+    return ['prettierd', 'prettier']
 endfunction
 
 function! neoformat#formatters#solidity#prettier() abort
@@ -11,3 +11,10 @@ function! neoformat#formatters#solidity#prettier() abort
         \ }
 endfunction
 
+function! neoformat#formatters#solidity#prettierd() abort
+    return {
+        \ 'exe': 'prettierd',
+        \ 'args': ['"%:p"'],
+        \ 'stdin': 1,
+        \ }
+endfunction

--- a/autoload/neoformat/formatters/svelte.vim
+++ b/autoload/neoformat/formatters/svelte.vim
@@ -1,5 +1,5 @@
 function! neoformat#formatters#svelte#enabled() abort
-    return ['prettier']
+    return ['prettierd', 'prettier']
 endfunction
 
 function! neoformat#formatters#svelte#prettier() abort
@@ -8,5 +8,13 @@ function! neoformat#formatters#svelte#prettier() abort
         \ 'args': ['--stdin-filepath', '"%:p"', '--parser=svelte', '--plugin-search-dir=.'],
         \ 'stdin': 1,
         \ 'try_node_exe': 1,
+        \ }
+endfunction
+
+function! neoformat#formatters#svelte#prettierd() abort
+    return {
+        \ 'exe': 'prettierd',
+        \ 'args': ['"%:p"'],
+        \ 'stdin': 1,
         \ }
 endfunction

--- a/autoload/neoformat/formatters/typescript.vim
+++ b/autoload/neoformat/formatters/typescript.vim
@@ -1,5 +1,5 @@
 function! neoformat#formatters#typescript#enabled() abort
-   return ['tsfmt', 'prettier', 'prettiereslint', 'tslint', 'eslint_d', 'clangformat', 'denofmt']
+   return ['tsfmt', 'prettierd', 'prettier', 'prettiereslint', 'tslint', 'eslint_d', 'clangformat', 'denofmt']
 endfunction
 
 function! neoformat#formatters#typescript#tsfmt() abort
@@ -17,6 +17,14 @@ function! neoformat#formatters#typescript#prettier() abort
         \ 'args': ['--stdin-filepath', '"%:p"', '--parser', 'typescript'],
         \ 'stdin': 1,
         \ 'try_node_exe': 1,
+        \ }
+endfunction
+
+function! neoformat#formatters#typescript#prettierd() abort
+    return {
+        \ 'exe': 'prettierd',
+        \ 'args': ['"%:p"'],
+        \ 'stdin': 1,
         \ }
 endfunction
 

--- a/autoload/neoformat/formatters/typescriptreact.vim
+++ b/autoload/neoformat/formatters/typescriptreact.vim
@@ -20,6 +20,14 @@ function! neoformat#formatters#typescriptreact#prettier() abort
         \ }
 endfunction
 
+function! neoformat#formatters#typescriptreact#prettierd() abort
+    return {
+        \ 'exe': 'prettierd',
+        \ 'args': ['"%:p"'],
+        \ 'stdin': 1,
+        \ }
+endfunction
+
 function! neoformat#formatters#typescriptreact#prettiereslint() abort
     return {
         \ 'exe': 'prettier-eslint',

--- a/autoload/neoformat/formatters/typescriptreact.vim
+++ b/autoload/neoformat/formatters/typescriptreact.vim
@@ -1,5 +1,5 @@
 function! neoformat#formatters#typescriptreact#enabled() abort
-   return ['tsfmt', 'prettier', 'prettiereslint', 'tslint', 'eslint_d', 'clangformat', 'denofmt']
+   return ['tsfmt', 'prettierd', 'prettier', 'prettiereslint', 'tslint', 'eslint_d', 'clangformat', 'denofmt']
 endfunction
 
 function! neoformat#formatters#typescriptreact#tsfmt() abort

--- a/autoload/neoformat/formatters/vue.vim
+++ b/autoload/neoformat/formatters/vue.vim
@@ -1,5 +1,5 @@
 function! neoformat#formatters#vue#enabled() abort
-    return ['prettier']
+    return ['prettierd', 'prettier']
 endfunction
 
 function! neoformat#formatters#vue#prettier() abort
@@ -8,5 +8,13 @@ function! neoformat#formatters#vue#prettier() abort
         \ 'args': ['--stdin-filepath', '"%:p"', '--parser', 'vue'],
         \ 'stdin': 1,
         \ 'try_node_exe': 1,
+        \ }
+endfunction
+
+function! neoformat#formatters#vue#prettierd() abort
+    return {
+        \ 'exe': 'prettierd',
+        \ 'args': ['"%:p"'],
+        \ 'stdin': 1,
         \ }
 endfunction

--- a/autoload/neoformat/formatters/xml.vim
+++ b/autoload/neoformat/formatters/xml.vim
@@ -1,5 +1,5 @@
 function! neoformat#formatters#xml#enabled() abort
-   return ['tidy', 'prettydiff', 'prettier']
+   return ['tidy', 'prettydiff', 'prettierd', 'prettier']
 endfunction
 
 function! neoformat#formatters#xml#tidy() abort
@@ -30,4 +30,10 @@ function! neoformat#formatters#xml#prettier() abort
         \ }
 endfunction
 
-
+function! neoformat#formatters#xml#prettierd() abort
+    return {
+        \ 'exe': 'prettierd',
+        \ 'args': ['"%:p"'],
+        \ 'stdin': 1,
+        \ }
+endfunction

--- a/autoload/neoformat/formatters/yaml.vim
+++ b/autoload/neoformat/formatters/yaml.vim
@@ -1,5 +1,5 @@
 function! neoformat#formatters#yaml#enabled() abort
-   return ['pyaml', 'prettier']
+   return ['pyaml', 'prettierd', 'prettier']
 endfunction
 
 function! neoformat#formatters#yaml#pyaml() abort
@@ -17,4 +17,12 @@ function! neoformat#formatters#yaml#prettier() abort
             \ 'stdin': 1,
             \ 'try_node_exe': 1,
             \ }
+endfunction
+
+function! neoformat#formatters#yaml#prettierd() abort
+    return {
+        \ 'exe': 'prettierd',
+        \ 'args': ['"%:p"'],
+        \ 'stdin': 1,
+        \ }
 endfunction

--- a/doc/neoformat.txt
+++ b/doc/neoformat.txt
@@ -246,6 +246,7 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
   - `crystal tool format` (ships with [`crystal`](http://crystal-lang.org))
 - CSS
   - `css-beautify` (ships with [`js-beautify`](https://github.com/beautify-web/js-beautify)),
+    [`prettierd`](https://github.com/fsouza/prettierd),
     [`prettier`](https://github.com/prettier/prettier),
     [`prettydiff`](https://github.com/prettydiff/prettydiff),
     [`stylefmt`](https://github.com/morishitter/stylefmt),
@@ -289,7 +290,8 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
 - GLSL
   - [`clang-format`](http://clang.llvm.org/docs/ClangFormat.html)
 - GraphQL
-  - [`prettier`](https://github.com/prettier/prettier)
+  - [`prettierd`](https://github.com/fsouza/prettierd),
+    [`prettier`](https://github.com/prettier/prettier)
 - Haskell
   - [`stylishhaskell`](https://github.com/jaspervdj/stylish-haskell)
   - [`hindent`](https://github.com/chrisdone/hindent)
@@ -311,6 +313,7 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
   - [`purty`](https://gitlab.com/joneshf/purty)
 - HTML
   - `html-beautify` (ships with [`js-beautify`](https://github.com/beautify-web/js-beautify)),
+    [`prettierd`](https://github.com/fsouza/prettierd),
     [`prettier`](https://github.com/jlongster/prettier),
     [`prettydiff`](https://github.com/prettydiff/prettydiff)
 - Jade
@@ -318,9 +321,11 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
 - Java
   - [`uncrustify`](http://uncrustify.sourceforge.net),
     [`astyle`](http://astyle.sourceforge.net)
+    [`prettierd`](https://github.com/fsouza/prettierd),
     [`prettier`](https://github.com/prettier/prettier)
 - JavaScript
   - [`js-beautify`](https://github.com/beautify-web/js-beautify),
+    [`prettierd`](https://github.com/fsouza/prettierd),
     [`prettier`](https://github.com/jlongster/prettier),
     [`prettydiff`](https://github.com/prettydiff/prettydiff),
     [`clang-format`](http://clang.llvm.org/docs/ClangFormat.html),
@@ -333,17 +338,20 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
 - JSON
   - [`js-beautify`](https://github.com/beautify-web/js-beautify),
     [`prettydiff`](https://github.com/prettydiff/prettydiff),
+    [`prettierd`](https://github.com/fsouza/prettierd),
     [`prettier`](https://github.com/prettier/prettier),
     [`jq`](https://stedolan.github.io/jq/),
     [`fixjson`](https://github.com/rhysd/fixjson)
     [`deno fmt`](https://deno.land/manual/tools/formatter)
 - Kotlin
   - [`ktlint`](https://github.com/shyiko/ktlint)
+    [`prettierd`](https://github.com/fsouza/prettierd),
     [`prettier`](https://github.com/prettier/prettier)
 - LaTeX
   - [`latexindent`](https://github.com/cmhughes/latexindent.pl)
 - Less
   - [`csscomb`](http://csscomb.com),
+    [`prettierd`](https://github.com/fsouza/prettierd),
     [`prettier`](https://github.com/prettier/prettier),
     [`prettydiff`](https://github.com/prettydiff/prettydiff),
     [`stylelint`](https://stylelint.io/)
@@ -354,6 +362,7 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
   - [`stylua`](https://github.com/JohnnyMorganz/StyLua)
 - Markdown
   - [`remark`](https://github.com/wooorm/remark)
+    [`prettierd`](https://github.com/fsouza/prettierd),
     [`prettier`](https://github.com/prettier/prettier),
     [`deno fmt`](https://deno.land/manual/tools/formatter)
 - Matlab
@@ -382,7 +391,8 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
   - [`php_beautifier`](http://pear.php.net/package/PHP_Beautifier)
   - [`php-cs-fixer`](http://cs.sensiolabs.org/)
   - [`phpcbf`](https://github.com/squizlabs/PHP_CodeSniffer)
-  - [`prettier`](https://github.com/prettier/plugin-php)
+  - [`prettierd`](https://github.com/fsouza/prettierd),
+    [`prettier`](https://github.com/prettier/plugin-php)
 - PowerShell
   - [`PSScriptAnalyzer`](https://github.com/PowerShell/PSScriptAnalyzer),
     [`PowerShell-Beautifier`](https://github.com/DTW-DanWard/PowerShell-Beautifier)
@@ -423,13 +433,15 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
   - [`sass-convert`](http://sass-lang.com/documentation/#executables),
     [`stylefmt`](https://github.com/morishitter/stylefmt),
     [`stylelint`](https://stylelint.io/)
+    [`prettierd`](https://github.com/fsouza/prettierd),
     [`prettier`](https://github.com/prettier/prettier),
     [`prettydiff`](https://github.com/prettydiff/prettydiff),
     [`csscomb`](http://csscomb.com)
 - Shell
   - [`shfmt`](https://github.com/mvdan/sh)
 - Solidity
-  - [`prettier`](https://github.com/prettier-solidity/prettier-plugin-solidity)
+  - [`prettierd`](https://github.com/fsouza/prettierd),
+    [`prettier`](https://github.com/prettier-solidity/prettier-plugin-solidity)
 - SQL
   - [`sqlfmt`](https://github.com/jackc/sqlfmt)
   - `sqlformat` (ships with [`sqlparse`](https://github.com/andialbrecht/sqlparse))
@@ -439,13 +451,15 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
 - SugarSS
   - [`stylelint`](https://stylelint.io/)
 - Svelte
-  - [`prettier-plugin-svelte`](https://github.com/UnwrittenFun/prettier-plugin-svelte)
+  - [`prettierd`](https://github.com/fsouza/prettierd),
+    [`prettier-plugin-svelte`](https://github.com/UnwrittenFun/prettier-plugin-svelte)
 - Swift
   - [`Swiftformat`](https://github.com/nicklockwood/SwiftFormat)
 - Terraform
   - [`terraform`](https://www.terraform.io/docs/commands/fmt.html)
 - TypeScript
   - [`tsfmt`](https://github.com/vvakame/typescript-formatter),
+    [`prettierd`](https://github.com/fsouza/prettierd),
     [`prettier`](https://github.com/prettier/prettier),
     [`prettier-eslint`](https://github.com/kentcdodds/prettier-eslint-cli),
     [`tslint`](https://palantir.github.io/tslint)
@@ -459,17 +473,20 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
 - VALA
   - [`uncrustify`](http://uncrustify.sourceforge.net)
 - Vue
-  - [`prettier`](https://github.com/prettier/prettier)
+  - [`prettier`](https://github.com/prettier/prettier),
+    [`prettierd`](https://github.com/fsouza/prettierd)
 - XHTML
   - [`tidy`](http://www.html-tidy.org),
     [`prettydiff`](https://github.com/prettydiff/prettydiff)
 - XML
   - [`tidy`](http://www.html-tidy.org),
     [`prettydiff`](https://github.com/prettydiff/prettydiff)
-    [`prettier`](https://github.com/prettier/prettier)
+    [`prettier`](https://github.com/prettier/prettier),
+    [`prettierd`](https://github.com/fsouza/prettierd)
 - YAML
   - [`pyaml`](https://pypi.python.org/pypi/pyaml),
-    [`prettier`](https://github.com/prettier/prettier)
+    [`prettier`](https://github.com/prettier/prettier),
+    [`prettierd`](https://github.com/fsouza/prettierd)
 - zig
   - [`zig fmt`](https://github.com/ziglang/zig)
 - zsh


### PR DESCRIPTION
Closes https://github.com/sbdchd/neoformat/issues/373

This PR adds [`prettierd`](https://github.com/fsouza/prettierd) to the available formatters.

- Everywhere that prettier was present, there is now also an entry for prettierd.
- prettierd is preferred over prettier, when it is installed.

In some cases, the arguments passed to prettier include additional options (e.g., [vue](https://github.com/sbdchd/neoformat/blob/master/autoload/neoformat/formatters/svelte.vim)). **I did not try to preserve those options in the prettierd flags.** I'm not sure if this will cause problems for anyone; those options haven't been needed in my use cases yet.

