### PR TITLE
Add support for standardrb formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,7 +445,8 @@ that caused Neoformat to be invoked.
 - Ruby
   - [`rufo`](https://github.com/ruby-formatter/rufo),
     [`ruby-beautify`](https://github.com/erniebrodeur/ruby-beautify),
-    [`rubocop`](https://github.com/bbatsov/rubocop)
+    [`rubocop`](https://github.com/rubocop/rubocop),
+    [`standard`](https://github.com/testdouble/standard)
     [`prettier`](https://github.com/prettier/plugin-ruby)
 - Rust
   - [`rustfmt`](https://github.com/rust-lang-nursery/rustfmt)
@@ -481,7 +482,7 @@ that caused Neoformat to be invoked.
 - Starlark
   - [`buildifier`](https://github.com/bazelbuild/buildtools/blob/master/buildifier/README.md)
 - SugarSS
-    [`stylelint`](https://stylelint.io/)
+  [`stylelint`](https://stylelint.io/)
 - Svelte
   - [`prettierd`](https://github.com/fsouza/prettierd),
     [`prettier-plugin-svelte`](https://github.com/UnwrittenFun/prettier-plugin-svelte)

--- a/autoload/neoformat/formatters/ruby.vim
+++ b/autoload/neoformat/formatters/ruby.vim
@@ -1,5 +1,5 @@
 function! neoformat#formatters#ruby#enabled() abort
-   return ['rufo', 'rubybeautify', 'rubocop', 'prettier']
+   return ['rufo', 'rubybeautify', 'standard', 'rubocop', 'prettier']
 endfunction
 
 function! neoformat#formatters#ruby#rufo() abort
@@ -17,10 +17,21 @@ function! neoformat#formatters#ruby#rubybeautify() abort
         \ }
 endfunction
 
+let s:clean_output = "awk '/^====================$/{p++;if(p==1){next}}p'"
+
 function! neoformat#formatters#ruby#rubocop() abort
      return {
         \ 'exe': 'rubocop',
-        \ 'args': ['--auto-correct', '--stdin', '"%:p"', '2>/dev/null', '|', 'sed "1,/^====================$/d"'],
+        \ 'args': ['--auto-correct', '--stdin', '"%:p"', '2>/dev/null', '|', s:clean_output],
+        \ 'stdin': 1,
+        \ 'stderr': 1
+        \ }
+endfunction
+
+function! neoformat#formatters#ruby#standard() abort
+     return {
+        \ 'exe': 'standardrb',
+        \ 'args': ['--fix', '--stdin', '"%:p"', '2>/dev/null', '|', s:clean_output],
         \ 'stdin': 1,
         \ 'stderr': 1
         \ }

--- a/doc/neoformat.txt
+++ b/doc/neoformat.txt
@@ -423,7 +423,8 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
 - Ruby
   - [`rufo`](https://github.com/asterite/rufo)
   - [`ruby-beautify`](https://github.com/erniebrodeur/ruby-beautify)
-  - [`rubocop`](https://github.com/bbatsov/rubocop)
+  - [`rubocop`](https://github.com/rubocop/rubocop)
+  - [`standard`](https://github.com/testdouble/standard)
   - [`prettier`](https://github.com/prettier/plugin-ruby)
 - Rust
   - [`rustfmt`](https://github.com/rust-lang-nursery/rustfmt)
@@ -503,3 +504,4 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
 
 ==============================================================================
 vim:tw=78:ts=8:ft=help:norl:noet:fen:noet:
+


### PR DESCRIPTION
- https://github.com/testdouble/standard is an opinionated wrapper around rubocop.
- Update documentation for ruby#standard
- Also use the current repo URL for rubocop