### PR TITLE
feat: add rustfmt_edition_opt

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,9 @@ that caused Neoformat to be invoked.
     [`rubocop`](https://github.com/bbatsov/rubocop)
 - Rust
   - [`rustfmt`](https://github.com/rust-lang-nursery/rustfmt)
+    ```vim
+    let g:rustfmt_edition_opt="2021"
+    ```
 - Sass
   - [`sass-convert`](http://sass-lang.com/documentation/#executables),
     [`stylelint`](https://stylelint.io/),

--- a/autoload/neoformat/formatters/rust.vim
+++ b/autoload/neoformat/formatters/rust.vim
@@ -3,8 +3,12 @@ function! neoformat#formatters#rust#enabled() abort
 endfunction
 
 function! neoformat#formatters#rust#rustfmt() abort
+    let opts = get(g:, 'rustfmt_edition_opt', '')
+    if opts != ''
+        let opts = '--edition ' . opts
     return {
         \ 'exe': 'rustfmt',
+        \ 'args': [opts],
         \ 'stdin': 1,
         \ }
 endfunction


### PR DESCRIPTION
supports optional `rustfmt` --edition version.