### PR TITLE
Fix deno fmt for Markdown

### DIFF
--- a/autoload/neoformat/formatters/markdown.vim
+++ b/autoload/neoformat/formatters/markdown.vim
@@ -31,7 +31,7 @@ endfunction
 function! neoformat#formatters#markdown#denofmt() abort
     return {
         \ 'exe': 'deno',
-        \ 'args': ['fmt','-'],
+        \ 'args': ['fmt', '--ext', 'md', '-'],
         \ 'stdin': 1,
         \ }
 endfunction


### PR DESCRIPTION
```
--ext <ext>                                      Set standard input (stdin) content type [default: ts] [possible values: ts, tsx, js, jsx, md, json, jsonc]
```

Deno expects JavaScript by default and just throws syntax errors, if you call neoformat on a Markdown buffer.