### PR TITLE
Fix tabs in shfmt

### DIFF
--- a/autoload/neoformat/formatters/ebuild.vim
+++ b/autoload/neoformat/formatters/ebuild.vim
@@ -3,8 +3,7 @@ function! neoformat#formatters#ebuild#enabled() abort
 endfunction
 
 function! neoformat#formatters#ebuild#shfmt() abort
-    let opts = get(g:, 'shfmt_opt', '')
-
+    let opts = neoformat#utils#var_default('shfmt_opt', '')
     return {
             \ 'exe': 'shfmt',
             \ 'args': ['-i ' . (&expandtab ? shiftwidth() : 0), opts],

--- a/autoload/neoformat/formatters/sh.vim
+++ b/autoload/neoformat/formatters/sh.vim
@@ -3,11 +3,10 @@ function! neoformat#formatters#sh#enabled() abort
 endfunction
 
 function! neoformat#formatters#sh#shfmt() abort
-    let opts = get(g:, 'shfmt_opt', '')
-
+    let opts = neoformat#utils#var_default('shfmt_opt', '')
     return {
             \ 'exe': 'shfmt',
-            \ 'args': ['-i ' . shiftwidth(), opts],
+            \ 'args': ['-i ' . (&expandtab ? shiftwidth() : 0), opts],
             \ 'stdin': 1,
             \ }
 endfunction

--- a/autoload/neoformat/formatters/zsh.vim
+++ b/autoload/neoformat/formatters/zsh.vim
@@ -3,11 +3,10 @@ function! neoformat#formatters#zsh#enabled() abort
 endfunction
 
 function! neoformat#formatters#zsh#shfmt() abort
-    let opts = get(g:, 'shfmt_opt', '')
-
+    let opts = neoformat#utils#var_default('shfmt_opt', '')
     return {
             \ 'exe': 'shfmt',
-            \ 'args': ['-i ' . shiftwidth(), opts],
+            \ 'args': ['-i ' . (&expandtab ? shiftwidth() : 0), opts],
             \ 'stdin': 1,
             \ }
 endfunction


### PR DESCRIPTION
If `expandtab` is not set, do not pass `shiftwidth` to shfmt. shfmt uses tabs by default.