### PR TITLE
feat: add yamlfmt support for YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,7 +516,8 @@ that caused Neoformat to be invoked.
 - YAML
   - [`pyaml`](https://pypi.python.org/pypi/pyaml),
     [`prettierd`](https://github.com/fsouza/prettierd),
-    [`prettier`](https://github.com/prettier/prettier)
+    [`prettier`](https://github.com/prettier/prettier),
+    [`yamlfmt`](https://github.com/mmlb/yamlfmt)
 - zig
   - [`zigformat`](https://github.com/Himujjal/zigformat)
     [`zig fmt`](https://github.com/ziglang/zig)

--- a/autoload/neoformat/formatters/yaml.vim
+++ b/autoload/neoformat/formatters/yaml.vim
@@ -1,5 +1,5 @@
 function! neoformat#formatters#yaml#enabled() abort
-   return ['pyaml', 'prettierd', 'prettier']
+   return ['pyaml', 'prettierd', 'prettier', 'yamlfmt']
 endfunction
 
 function! neoformat#formatters#yaml#pyaml() abort
@@ -23,6 +23,13 @@ function! neoformat#formatters#yaml#prettierd() abort
     return {
         \ 'exe': 'prettierd',
         \ 'args': ['"%:p"'],
+        \ 'stdin': 1,
+        \ }
+endfunction
+
+function! neoformat#formatters#yaml#yamlfmt() abort
+    return {
+        \ 'exe': 'yamlfmt',
         \ 'stdin': 1,
         \ }
 endfunction

--- a/doc/neoformat.txt
+++ b/doc/neoformat.txt
@@ -493,7 +493,8 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
 - YAML
   - [`pyaml`](https://pypi.python.org/pypi/pyaml),
     [`prettier`](https://github.com/prettier/prettier),
-    [`prettierd`](https://github.com/fsouza/prettierd)
+    [`prettierd`](https://github.com/fsouza/prettierd),
+    [`yamlfmt`](https://github.com/mmlb/yamlfmt)
 - zig
   - [`zigformat`](https://github.com/Himujjal/zigformat)
     [`zig fmt`](https://github.com/ziglang/zig)


### PR DESCRIPTION
`yamlfmt` is an opionated yaml formatter, and it supports keeping comments.

https://github.com/mmlb/yamlfmt