### PR TITLE
fix: laravel pint not shown as an option

### DIFF
--- a/autoload/neoformat/formatters/php.vim
+++ b/autoload/neoformat/formatters/php.vim
@@ -1,5 +1,5 @@
 function! neoformat#formatters#php#enabled() abort
-    return ['phpbeautifier', 'phpcsfixer', 'phpcbf', 'prettierd', 'prettier']
+    return ['phpbeautifier', 'phpcsfixer', 'phpcbf', 'prettierd', 'prettier', 'laravelpint']
 endfunction
 
 function! neoformat#formatters#php#phpbeautifier() abort


### PR DESCRIPTION
Laravel Pint is not shown as an option. This change adds an entry for Pint to the list shown to the user.