### PR TITLE
cabalfmt: use filepath arg instead of stdin

### DIFF
--- a/autoload/neoformat/formatters/cabal.vim
+++ b/autoload/neoformat/formatters/cabal.vim
@@ -5,6 +5,7 @@ endfunction
 function! neoformat#formatters#cabal#cabalfmt() abort
     return {
         \ 'exe' : 'cabal-fmt',
-        \ 'stdin' : 1,
+        \ 'args' : ["%:p"],
+        \ 'no_append': 1,
         \ }
 endfunction


### PR DESCRIPTION
disclaimer: idk what I'm doing

my reasoning:
I wanted to let cabal-fmt auto-fill a field, but that didn't seem to be working due to current configuration feeding the content to cabal-fmt through stdin, so I wish to change it.
By default it seems neoformat uses a temporary path when passing file path by arg. That's also not good enough as cabal-fmt needs access to the project location.
I assume that the reason for using a temp path is that some tools make in-place changes. cabal-fmt only does so when asked to with `-i, --in-place`

does this break stuff for others?: I wouldn't know.

feel free to discard or whatever. I just made what seemed like an improvement to me, and figured out how to make the pull request.