### PR TITLE
feat: add verible-verilog-format as verilog and system verilog formatter

### DIFF
--- a/autoload/neoformat/formatters/systemverilog.vim
+++ b/autoload/neoformat/formatters/systemverilog.vim
@@ -1,0 +1,7 @@
+function! neoformat#formatters#systemverilog#enabled() abort
+   return ['veribleverilogformat']
+endfunction
+
+function! neoformat#formatters#systemverilog#veribleverilogformat() abort
+    return neoformat#formatters#verilog#veribleverilogformat()
+endfunction

--- a/autoload/neoformat/formatters/verilog.vim
+++ b/autoload/neoformat/formatters/verilog.vim
@@ -1,0 +1,9 @@
+function! neoformat#formatters#verilog#enabled() abort
+   return ['veribleverilogformat']
+endfunction
+
+function! neoformat#formatters#verilog#veribleverilogformat() abort
+    return {
+            \ 'exe': 'verible-verilog-format',
+            \ }
+endfunction


### PR DESCRIPTION
verible-verilog-format is a tool for formatting Verilog and SystemVerilog code. Part of the Verible tool suite.
The more detailed information, you can refer to https://chipsalliance.github.io/verible/ . Thanks.