### PR TITLE
doc: add caddyfile related info to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,8 @@ that caused Neoformat to be invoked.
     [`astyle`](http://astyle.sourceforge.net)
 - Cabal
   - [`cabal-fmt`](https://github.com/phadej/cabal-fmt)
+- Caddyfile
+  - [`caddy fmt`](https://caddyserver.com/docs/command-line#caddy-fmt)
 - CMake
   - [`cmake_format`](https://github.com/cheshirekow/cmake_format)
 - Crystal

--- a/autoload/neoformat/formatters/caddyfile.vim
+++ b/autoload/neoformat/formatters/caddyfile.vim
@@ -5,7 +5,7 @@ endfunction
 function! neoformat#formatters#caddyfile#caddyformat() abort
     return {
             \ 'exe': 'caddy',
-            \ 'args': ['fmt'],
+            \ 'args': ['fmt', '-'],
             \ 'stdin': 1,
             \ }
 endfunction


### PR DESCRIPTION
1. add caddyfile related information to README
2. fix an error that `caddy fmt` cannot read file content correctly