### PR TITLE
Fixing solidity/forge integration

### DIFF
--- a/autoload/neoformat/formatters/solidity.vim
+++ b/autoload/neoformat/formatters/solidity.vim
@@ -22,7 +22,7 @@ endfunction
 function! neoformat#formatters#solidity#forge() abort
     return {
         \ 'exe': 'forge',
-        \ 'args': ['fmt', '--check', '--raw', '"%:p"'],
-        \ 'valid_exit_codes': [0, 1],
+        \ 'args': ['fmt', '--raw', '-'],
+        \ 'stdin': 1
         \ }
 endfunction


### PR DESCRIPTION
There were two different problems:
* `forge fmt` does support stdin, by sending `-` instead of a path. I assume this is a better approach?
* the `--check` flag causes `forge` to send an exit code `1` when invalid syntax is found. However, it also causes it to not send any output, resulting in the buffer becoming empty. Removing this flag fixes it, and also makes `valid_exit_codes` unnecessary