### PR TITLE
escape character in clangd fix

### DIFF
--- a/autoload/neoformat/formatters/c.vim
+++ b/autoload/neoformat/formatters/c.vim
@@ -13,7 +13,7 @@ endfunction
 function! neoformat#formatters#c#clangformat() abort
     return {
             \ 'exe': 'clang-format',
-            \ 'args': ['-assume-filename=' . expand('%:t')],
+            \ 'args': ['-assume-filename=' . expand('"%:t"')],
             \ 'stdin': 1,
             \ }
 endfunction


### PR DESCRIPTION
Otherwise, it fails with filenames with spaces.