### PR TITLE
fix: add content type to deno fmt calls

### DIFF
--- a/autoload/neoformat/formatters/javascript.vim
+++ b/autoload/neoformat/formatters/javascript.vim
@@ -87,7 +87,7 @@ endfunction
 function! neoformat#formatters#javascript#denofmt() abort
     return {
         \ 'exe': 'deno',
-        \ 'args': ['fmt','-'],
+        \ 'args': ['fmt','--ext','js','-'],
         \ 'stdin': 1,
         \ }
 endfunction

--- a/autoload/neoformat/formatters/javascriptreact.vim
+++ b/autoload/neoformat/formatters/javascriptreact.vim
@@ -78,7 +78,7 @@ endfunction
 function! neoformat#formatters#javascriptreact#denofmt() abort
     return {
         \ 'exe': 'deno',
-        \ 'args': ['fmt','-'],
+        \ 'args': ['fmt','--ext','jsx','-'],
         \ 'stdin': 1,
         \ }
 endfunction

--- a/autoload/neoformat/formatters/json.vim
+++ b/autoload/neoformat/formatters/json.vim
@@ -47,7 +47,7 @@ endfunction
 function! neoformat#formatters#json#denofmt() abort
     return {
         \ 'exe': 'deno',
-        \ 'args': ['fmt','-'],
+        \ 'args': ['fmt','--ext','json','-'],
         \ 'stdin': 1,
         \ }
 endfunction

--- a/autoload/neoformat/formatters/jsonc.vim
+++ b/autoload/neoformat/formatters/jsonc.vim
@@ -22,7 +22,7 @@ endfunction
 function! neoformat#formatters#jsonc#denofmt() abort
     return {
         \ 'exe': 'deno',
-        \ 'args': ['fmt','-'],
+        \ 'args': ['fmt','--ext','jsonc','-'],
         \ 'stdin': 1,
         \ }
 endfunction

--- a/autoload/neoformat/formatters/typescript.vim
+++ b/autoload/neoformat/formatters/typescript.vim
@@ -71,5 +71,9 @@ function! neoformat#formatters#typescript#clangformat() abort
 endfunction
 
 function! neoformat#formatters#typescript#denofmt() abort
-    return neoformat#formatters#javascript#denofmt()
+    return {
+        \ 'exe': 'deno',
+        \ 'args': ['fmt','--ext','ts','-'],
+        \ 'stdin': 1,
+        \ }
 endfunction

--- a/autoload/neoformat/formatters/typescriptreact.vim
+++ b/autoload/neoformat/formatters/typescriptreact.vim
@@ -71,5 +71,9 @@ function! neoformat#formatters#typescriptreact#clangformat() abort
 endfunction
 
 function! neoformat#formatters#typescriptreact#denofmt() abort
-    return neoformat#formatters#javascript#denofmt()
+    return {
+        \ 'exe': 'deno',
+        \ 'args': ['fmt','--ext','tsx','-'],
+        \ 'stdin': 1,
+        \ }
 endfunction


### PR DESCRIPTION
Deno changed the default behavior for fmt calls using stdin content. By default it assumes all input is TypeScript and otherwise it needs to be specified by the --ext option. This adds the appropriate --ext flags for all file types associated with Deno (except markdown since that was added in an earlier).

Signed-off-by: StaticRocket <35777938+StaticRocket@users.noreply.github.com>