### PR TITLE
feat: xml: add xmllint parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,7 +522,8 @@ that caused Neoformat to be invoked.
   - [`tidy`](http://www.html-tidy.org),
     [`prettydiff`](https://github.com/prettydiff/prettydiff),
     [`prettierd`](https://github.com/fsouza/prettierd),
-    [`prettier`](https://github.com/prettier/prettier)
+    [`prettier`](https://github.com/prettier/prettier),
+    [`xmllint`](https://gitlab.gnome.org/GNOME/libxml2)
 - YAML
   - [`pyaml`](https://pypi.python.org/pypi/pyaml),
     [`prettierd`](https://github.com/fsouza/prettierd),

--- a/autoload/neoformat/formatters/xml.vim
+++ b/autoload/neoformat/formatters/xml.vim
@@ -1,5 +1,5 @@
 function! neoformat#formatters#xml#enabled() abort
-   return ['tidy', 'prettydiff', 'prettierd', 'prettier']
+   return ['tidy', 'prettydiff', 'prettierd', 'prettier', 'xmllint']
 endfunction
 
 function! neoformat#formatters#xml#tidy() abort
@@ -34,6 +34,14 @@ function! neoformat#formatters#xml#prettierd() abort
     return {
         \ 'exe': 'prettierd',
         \ 'args': ['"%:p"'],
+        \ 'stdin': 1,
+        \ }
+endfunction
+
+function! neoformat#formatters#xml#xmllint() abort
+    return {
+        \ 'exe': 'xmllint',
+        \ 'args': ['--format', '--quiet', '-'],
         \ 'stdin': 1,
         \ }
 endfunction

--- a/doc/neoformat.txt
+++ b/doc/neoformat.txt
@@ -494,7 +494,8 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
   - [`tidy`](http://www.html-tidy.org),
     [`prettydiff`](https://github.com/prettydiff/prettydiff)
     [`prettier`](https://github.com/prettier/prettier),
-    [`prettierd`](https://github.com/fsouza/prettierd)
+    [`prettierd`](https://github.com/fsouza/prettierd),
+    [`xmllint`](https://gitlab.gnome.org/GNOME/libxml2)
 - YAML
   - [`pyaml`](https://pypi.python.org/pypi/pyaml),
     [`prettier`](https://github.com/prettier/prettier),


### PR DESCRIPTION
Add the XML parser xmllint from libxml2. This parser is included with libxml2 which is a core dependency for a few Linux distros so it's probably a good idea to include it as a fallback option.

Signed-off-by: StaticRocket <35777938+StaticRocket@users.noreply.github.com>