### PR TITLE
feat(latexindent): add `opts` array to modify params

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,9 @@ that caused Neoformat to be invoked.
     [`prettier`](https://github.com/prettier/prettier)
 - LaTeX
   - [`latexindent`](https://github.com/cmhughes/latexindent.pl)
+    ```vim
+    let g:latexindent_opt="-m"
+    ```
 - Less
   - [`csscomb`](http://csscomb.com),
     [`prettydiff`](https://github.com/prettydiff/prettydiff),

--- a/autoload/neoformat/formatters/tex.vim
+++ b/autoload/neoformat/formatters/tex.vim
@@ -3,9 +3,10 @@ function! neoformat#formatters#tex#enabled() abort
 endfunction
 
 function! neoformat#formatters#tex#latexindent() abort
+    let opts = neoformat#utils#var_default('latexindent_opt', '')
     return {
         \ 'exe': 'latexindent',
-        \ 'args': ['-g /dev/stderr', '2>/dev/null'],
+        \ 'args': [opts, '-g /dev/stderr', '2>/dev/null'],
         \ 'stdin': 1,
         \ }
 endfunction


### PR DESCRIPTION
Hi!
This change makes easier to use `latexindent` with `-m` flag, that allows the formatter to modify linebreaks, and of course makes it possible to add some other parameters that might be useful for the final user.
Thanks!