### PR TITLE
Add fennel support

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,8 @@ that caused Neoformat to be invoked.
   - [`elm-format`](https://github.com/avh4/elm-format)
 - Erlang
   - [`erlfmt`](https://github.com/WhatsApp/erlfmt)
+- Fennel
+  - [`fnlfmt`](https://git.sr.ht/~technomancy/fnlfmt)
 - Fish
   - [`fish_indent`](http://fishshell.com)
 - Fortran

--- a/autoload/neoformat/formatters/fennel.vim
+++ b/autoload/neoformat/formatters/fennel.vim
@@ -1,0 +1,11 @@
+function! neoformat#formatters#fennel#enabled() abort
+  return ['fnlfmt']
+endfunction
+
+function! neoformat#formatters#fennel#fnlfmt() abort
+  return {
+        \ 'exe': 'fnlfmt',
+        \ 'args': ['--fix'],
+        \ 'replace': 1
+        \ }
+endfunction


### PR DESCRIPTION
This adds support for [fennel](https://fennel-lang.org) using [`fnlfmt`](https://fennel-lang.org/style). Let me know if I missed anything to add this! 