### PR TITLE
Add bibtex modern formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ that caused Neoformat to be invoked.
 - Blade
   - [`blade-formatter`](https://github.com/shufo/blade-formatter)
 - Bib
+  - [bibtex-tidy](https://github.com/FlamingTempura/bibtex-tidy)
   - [bibclean](https://github.com/tobywf/bibclean)
 - C
   - [`uncrustify`](http://uncrustify.sourceforge.net),

--- a/autoload/neoformat/formatters/bib.vim
+++ b/autoload/neoformat/formatters/bib.vim
@@ -1,10 +1,17 @@
 function! neoformat#formatters#bib#enabled() abort
-    return ['bibclean']
+    return ['bibclean', 'bibtextidy']
 endfunction
 
 function! neoformat#formatters#bib#bibclean() abort
     return {
                 \ 'exe': 'bibclean',
+                \ 'stdin': 1,
+                \ }
+endfunction
+
+function! neoformat#formatters#bib#bibtextidy() abort
+    return {
+                \ 'exe': 'bibtex-tidy',
                 \ 'stdin': 1,
                 \ }
 endfunction

--- a/doc/neoformat.txt
+++ b/doc/neoformat.txt
@@ -227,6 +227,7 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
 - Beancount
   - [`bean-format`](https://beancount.github.io/docs/running_beancount_and_generating_reports.html#bean-format)
 - Bib
+  - [bibtex-tidy](https://github.com/FlamingTempura/bibtex-tidy)
   - [bibclean](https://github.com/tobywf/bibclean)
 - C
   - [`uncrustify`](http://uncrustify.sourceforge.net),


### PR DESCRIPTION
This PR brings a new (more modern) formatter for Bibtex entries.

All the info for the required formatter (how to install, etc) is on the official docs of  [bibtex-tidy](https://github.com/FlamingTempura/bibtex-tidy)


https://user-images.githubusercontent.com/21349875/231716380-88489c1b-4c82-45a7-a047-eb2d39fe1487.mov

