### PR TITLE
Use full path with clang-format

### DIFF
--- a/autoload/neoformat/formatters/c.vim
+++ b/autoload/neoformat/formatters/c.vim
@@ -13,7 +13,7 @@ endfunction
 function! neoformat#formatters#c#clangformat() abort
     return {
             \ 'exe': 'clang-format',
-            \ 'args': ['-assume-filename=' . expand('"%:t"')],
+            \ 'args': ['-assume-filename=' . expand('"%"')],
             \ 'stdin': 1,
             \ }
 endfunction


### PR DESCRIPTION
`clang-format` receives file name without the path part in the `-assume-file` parameter and thus isn't able to find the style config closest to the file's location. For a file `subproject/main.c` it will use `./.clang-format` instead of `subproject/.clang-format`. Change the parameter to `%` instead of `%:t` to receive full path for the file being formatted. 

Fixes #459 