### PR TITLE
Add HCL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,8 @@ that caused Neoformat to be invoked.
     " wrong
     let g:neoformat_enabled_haskell = ['sort-imports', 'stylish-haskell']
     ```
+- HCL
+  - [`hclfmt`](https://github.com/hashicorp/hcl)
 - Toml
   - [`taplo`](https://taplo.tamasfe.dev/cli)
 - Puppet

--- a/autoload/neoformat/formatters/hcl.vim
+++ b/autoload/neoformat/formatters/hcl.vim
@@ -1,0 +1,10 @@
+function! neoformat#formatters#hcl#enabled() abort
+    return ['hclfmt']
+endfunction
+
+function! neoformat#formatters#hcl#hclfmt() abort
+    return {
+        \ 'exe': 'hclfmt',
+        \ 'stdin': 1
+        \ }
+endfunction

--- a/doc/neoformat.txt
+++ b/doc/neoformat.txt
@@ -312,6 +312,8 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
     let g:neoformat_enabled_haskell = ['sortimports', 'stylishhaskell']
     " wrong
     let g:neoformat_enabled_haskell = ['sort-imports', 'stylish-haskell']
+- HCL
+  - [`hclfmt`](https://github.com/hashicorp/hcl)
 - Puppet
   - [`puppet-lint`](https://github.com/rodjek/puppet-lint)
 - PureScript


### PR DESCRIPTION
This adds support for [hcl](https://github.com/hashicorp/hcl) using [`hclfmt`](https://github.com/hashicorp/hcl/tree/main/cmd/hclfmt).

