### PR TITLE
Add `Rego` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,8 @@ that caused Neoformat to be invoked.
 - Reason
   - [`refmt`](https://github.com/facebook/reason)
   - [`bsrefmt`](https://github.com/bucklescript/bucklescript)
+- Rego
+  - [`opa fmt`](https://www.openpolicyagent.org/docs/latest/cli/#opa-fmt)
 - Ruby
   - [`rufo`](https://github.com/ruby-formatter/rufo),
     [`ruby-beautify`](https://github.com/erniebrodeur/ruby-beautify),

--- a/autoload/neoformat/formatters/rego.vim
+++ b/autoload/neoformat/formatters/rego.vim
@@ -1,0 +1,11 @@
+function! neoformat#formatters#rego#enabled() abort
+    return ['opafmt']
+endfunction
+
+function! neoformat#formatters#rego#opafmt() abort
+    return {
+        \ 'exe': 'opa',
+        \ 'args': ['fmt'],
+        \ 'stdin': 1,
+        \ }
+endfunction

--- a/doc/neoformat.txt
+++ b/doc/neoformat.txt
@@ -428,6 +428,8 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
 - Reason
   - [`refmt`](https://github.com/facebook/reason)
   - [`bsrefmt`](https://github.com/bucklescript/bucklescript)
+- Rego
+  - [`opa fmt`](https://www.openpolicyagent.org/docs/latest/cli/#opa-fmt)
 - Ruby
   - [`rufo`](https://github.com/asterite/rufo)
   - [`ruby-beautify`](https://github.com/erniebrodeur/ruby-beautify)


### PR DESCRIPTION
This adds support for [rego](https://www.openpolicyagent.org/docs/latest/policy-language/) using [`opa fmt`](https://www.openpolicyagent.org/docs/latest/cli/#opa-fmt).

