### PR TITLE
yaml: add yamlfix formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,7 +549,8 @@ that caused Neoformat to be invoked.
   - [`pyaml`](https://pypi.python.org/pypi/pyaml),
     [`prettierd`](https://github.com/fsouza/prettierd),
     [`prettier`](https://github.com/prettier/prettier),
-    [`yamlfmt`](https://github.com/mmlb/yamlfmt)
+    [`yamlfmt`](https://github.com/mmlb/yamlfmt),
+    [`yamlfix`](https://github.com/lyz-code/yamlfix)
 - zig
   - [`zigformat`](https://github.com/Himujjal/zigformat)
     [`zig fmt`](https://github.com/ziglang/zig)

--- a/autoload/neoformat/formatters/yaml.vim
+++ b/autoload/neoformat/formatters/yaml.vim
@@ -1,5 +1,5 @@
 function! neoformat#formatters#yaml#enabled() abort
-   return ['pyaml', 'prettierd', 'prettier', 'yamlfmt']
+   return ['pyaml', 'prettierd', 'prettier', 'yamlfmt', 'yamlfix']
 endfunction
 
 function! neoformat#formatters#yaml#pyaml() abort
@@ -30,6 +30,14 @@ endfunction
 function! neoformat#formatters#yaml#yamlfmt() abort
     return {
         \ 'exe': 'yamlfmt',
+        \ 'stdin': 1,
+        \ }
+endfunction
+
+function! neoformat#formatters#yaml#yamlfix() abort
+    return {
+        \ 'exe': 'yamlfix',
+        \ 'args': ['-'],
         \ 'stdin': 1,
         \ }
 endfunction

--- a/doc/neoformat.txt
+++ b/doc/neoformat.txt
@@ -516,7 +516,8 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
   - [`pyaml`](https://pypi.python.org/pypi/pyaml),
     [`prettier`](https://github.com/prettier/prettier),
     [`prettierd`](https://github.com/fsouza/prettierd),
-    [`yamlfmt`](https://github.com/mmlb/yamlfmt)
+    [`yamlfmt`](https://github.com/mmlb/yamlfmt),
+    [`yamlfix`](https://github.com/lyz-code/yamlfix)
 - zig
   - [`zigformat`](https://github.com/Himujjal/zigformat)
     [`zig fmt`](https://github.com/ziglang/zig)


### PR DESCRIPTION
Add the yamlfix formatter. It's also python based but it preserves comments and formats things a little closer to what yamllint wants.