### PR TITLE
Add Biomeformatter for JavaScript, TypeScript, React, JSON, and JSONC

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,8 @@ that caused Neoformat to be invoked.
     [`eslint_d`](https://github.com/mantoni/eslint_d.js),
     [`standard`](https://standardjs.com/),
     [`semistandard`](https://github.com/standard/semistandard),
-    [`deno fmt`](https://deno.land/manual/tools/formatter)
+    [`deno fmt`](https://deno.land/manual/tools/formatter),
+    [`biome format`](https://biomejs.dev)
 - JSON
   - [`js-beautify`](https://github.com/beautify-web/js-beautify),
     [`prettydiff`](https://github.com/prettydiff/prettydiff),
@@ -378,11 +379,13 @@ that caused Neoformat to be invoked.
     [`jq`](https://stedolan.github.io/jq/),
     [`fixjson`](https://github.com/rhysd/fixjson),
     [`deno fmt`](https://deno.land/manual/tools/formatter),
-    [`topiary`](https://topiary.tweag.io)
+    [`topiary`](https://topiary.tweag.io),
+    [`biome format`](https://biomejs.dev)
 - JSONC (JSON with comments)
   - [`prettierd`](https://github.com/fsouza/prettierd),
     [`prettier`](https://github.com/prettier/prettier),
-    [`deno fmt`](https://deno.land/manual/tools/formatter)
+    [`deno fmt`](https://deno.land/manual/tools/formatter),
+    [`biome format`](https://biomejs.dev)
 - jsonnet
   - [`jsonnetfmt`](https://github.com/google/jsonnet)
 - Kotlin
@@ -538,7 +541,8 @@ that caused Neoformat to be invoked.
     [`tslint`](https://palantir.github.io/tslint),
     [`eslint_d`](https://github.com/mantoni/eslint_d.js),
     [`clang-format`](http://clang.llvm.org/docs/ClangFormat.html),
-    [`deno fmt`](https://deno.land/manual/tools/formatter)
+    [`deno fmt`](https://deno.land/manual/tools/formatter),
+    [`biome format`](https://biomejs.dev)
 - V
   - `v fmt` (ships with [`v`](https://vlang.io))
 - VALA

--- a/autoload/neoformat/formatters/javascript.vim
+++ b/autoload/neoformat/formatters/javascript.vim
@@ -1,5 +1,5 @@
 function! neoformat#formatters#javascript#enabled() abort
-    return ['jsbeautify', 'standard', 'semistandard', 'prettierd', 'prettier', 'prettydiff', 'clangformat', 'esformatter', 'prettiereslint', 'eslint_d', 'denofmt']
+    return ['jsbeautify', 'standard', 'semistandard', 'prettierd', 'prettier', 'prettydiff', 'clangformat', 'esformatter', 'prettiereslint', 'eslint_d', 'denofmt', 'biome']
 endfunction
 
 function! neoformat#formatters#javascript#jsbeautify() abort
@@ -98,5 +98,15 @@ function! neoformat#formatters#javascript#semistandard() abort
         \ 'args': ['--stdin','--fix'],
         \ 'stdin': 1,
         \ 'try_node_exe': 1,
+        \ }
+endfunction
+
+function! neoformat#formatters#javascript#biome() abort
+    return {
+        \ 'exe': 'biome',
+        \ 'try_node_exe': 1,
+        \ 'args': ['format', '--stdin-file-path="%:p"'],
+        \ 'no_append': 1,
+        \ 'stdin': 1,
         \ }
 endfunction

--- a/autoload/neoformat/formatters/javascriptreact.vim
+++ b/autoload/neoformat/formatters/javascriptreact.vim
@@ -1,5 +1,5 @@
 function! neoformat#formatters#javascriptreact#enabled() abort
-    return ['jsbeautify', 'standard', 'semistandard', 'prettierd', 'prettier', 'prettydiff', 'esformatter', 'prettiereslint', 'eslint_d', 'denofmt']
+    return ['jsbeautify', 'standard', 'semistandard', 'prettierd', 'prettier', 'prettydiff', 'esformatter', 'prettiereslint', 'eslint_d', 'denofmt', 'biome']
 endfunction
 
 function! neoformat#formatters#javascriptreact#jsbeautify() abort
@@ -89,5 +89,15 @@ function! neoformat#formatters#javascriptreact#semistandard() abort
         \ 'args': ['--stdin','--fix'],
         \ 'stdin': 1,
         \ 'try_node_exe': 1,
+        \ }
+endfunction
+
+function! neoformat#formatters#javascriptreact#biome() abort
+    return {
+        \ 'exe': 'biome',
+        \ 'try_node_exe': 1,
+        \ 'args': ['format', '--stdin-file-path="%:p"'],
+        \ 'no_append': 1,
+        \ 'stdin': 1,
         \ }
 endfunction

--- a/autoload/neoformat/formatters/json.vim
+++ b/autoload/neoformat/formatters/json.vim
@@ -1,5 +1,5 @@
 function! neoformat#formatters#json#enabled() abort
-    return ['jsbeautify', 'prettydiff', 'prettierd', 'prettier', 'jq', 'fixjson', 'denofmt', 'topiary']
+    return ['jsbeautify', 'prettydiff', 'prettierd', 'prettier', 'jq', 'fixjson', 'denofmt', 'topiary', 'biome']
 endfunction
 
 function! neoformat#formatters#json#jsbeautify() abort
@@ -58,5 +58,15 @@ function! neoformat#formatters#json#topiary() abort
         \ 'no_append': 1,
         \ 'stdin': 1,
         \ 'args': ['format', '--language', '"json"' ]
+        \ }
+endfunction
+
+function! neoformat#formatters#json#biome() abort
+    return {
+        \ 'exe': 'biome',
+        \ 'try_node_exe': 1,
+        \ 'args': ['format', '--stdin-file-path="%:p"'],
+        \ 'no_append': 1,
+        \ 'stdin': 1,
         \ }
 endfunction

--- a/autoload/neoformat/formatters/jsonc.vim
+++ b/autoload/neoformat/formatters/jsonc.vim
@@ -1,5 +1,5 @@
 function! neoformat#formatters#jsonc#enabled() abort
-    return ['prettierd', 'prettier', 'denofmt']
+    return ['prettierd', 'prettier', 'denofmt', 'biome']
 endfunction
 
 function! neoformat#formatters#jsonc#prettier() abort
@@ -23,6 +23,16 @@ function! neoformat#formatters#jsonc#denofmt() abort
     return {
         \ 'exe': 'deno',
         \ 'args': ['fmt','--ext','jsonc','-'],
+        \ 'stdin': 1,
+        \ }
+endfunction
+
+function! neoformat#formatters#jsonc#biome() abort
+    return {
+        \ 'exe': 'biome',
+        \ 'try_node_exe': 1,
+        \ 'args': ['format', '--stdin-file-path="%:p"'],
+        \ 'no_append': 1,
         \ 'stdin': 1,
         \ }
 endfunction

--- a/autoload/neoformat/formatters/typescript.vim
+++ b/autoload/neoformat/formatters/typescript.vim
@@ -1,5 +1,5 @@
 function! neoformat#formatters#typescript#enabled() abort
-   return ['tsfmt', 'prettierd', 'prettier', 'prettiereslint', 'tslint', 'eslint_d', 'clangformat', 'denofmt']
+   return ['tsfmt', 'prettierd', 'prettier', 'prettiereslint', 'tslint', 'eslint_d', 'clangformat', 'denofmt', 'biome']
 endfunction
 
 function! neoformat#formatters#typescript#tsfmt() abort
@@ -74,6 +74,16 @@ function! neoformat#formatters#typescript#denofmt() abort
     return {
         \ 'exe': 'deno',
         \ 'args': ['fmt','--ext','ts','-'],
+        \ 'stdin': 1,
+        \ }
+endfunction
+
+function! neoformat#formatters#javascript#biome() abort
+    return {
+        \ 'exe': 'biome',
+        \ 'try_node_exe': 1,
+        \ 'args': ['format', '--stdin-file-path="%:p"'],
+        \ 'no_append': 1,
         \ 'stdin': 1,
         \ }
 endfunction

--- a/autoload/neoformat/formatters/typescriptreact.vim
+++ b/autoload/neoformat/formatters/typescriptreact.vim
@@ -1,5 +1,5 @@
 function! neoformat#formatters#typescriptreact#enabled() abort
-   return ['tsfmt', 'prettierd', 'prettier', 'prettiereslint', 'tslint', 'eslint_d', 'clangformat', 'denofmt']
+   return ['tsfmt', 'prettierd', 'prettier', 'prettiereslint', 'tslint', 'eslint_d', 'clangformat', 'denofmt', 'biome']
 endfunction
 
 function! neoformat#formatters#typescriptreact#tsfmt() abort
@@ -74,6 +74,16 @@ function! neoformat#formatters#typescriptreact#denofmt() abort
     return {
         \ 'exe': 'deno',
         \ 'args': ['fmt','--ext','tsx','-'],
+        \ 'stdin': 1,
+        \ }
+endfunction
+
+function! neoformat#formatters#typescriptreact#biome() abort
+    return {
+        \ 'exe': 'biome',
+        \ 'try_node_exe': 1,
+        \ 'args': ['format', '--stdin-file-path="%:p"'],
+        \ 'no_append': 1,
         \ 'stdin': 1,
         \ }
 endfunction

--- a/doc/neoformat.txt
+++ b/doc/neoformat.txt
@@ -345,6 +345,7 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
     [`standard`](https://standardjs.com/),
     [`semistandard`](https://github.com/standard/semistandard),
     [`deno fmt`](https://deno.land/manual/tools/formatter),
+    [`biome`](https://biomejs.dev)
 - JSON
   - [`js-beautify`](https://github.com/beautify-web/js-beautify),
     [`prettydiff`](https://github.com/prettydiff/prettydiff),
@@ -353,7 +354,8 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
     [`jq`](https://stedolan.github.io/jq/),
     [`fixjson`](https://github.com/rhysd/fixjson),
     [`deno fmt`](https://deno.land/manual/tools/formatter),
-    [`topiary`](https://topiary.tweag.io)
+    [`topiary`](https://topiary.tweag.io),
+    [`biome`](https://biomejs.dev)
 - Kotlin
   - [`ktlint`](https://github.com/shyiko/ktlint)
     [`prettierd`](https://github.com/fsouza/prettierd),
@@ -499,7 +501,8 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
     [`tslint`](https://palantir.github.io/tslint)
     [`eslint_d`](https://github.com/mantoni/eslint_d.js)
     [`clang-format`](http://clang.llvm.org/docs/ClangFormat.html),
-    [`deno fmt`](https://deno.land/manual/tools/formatter)
+    [`deno fmt`](https://deno.land/manual/tools/formatter),
+    [`biome`](https://biomejs.dev)
 - Toml
   - [`taplo`](https://taplo.tamasfe.dev/cli/usage/formatting.html),
     [`topiary`](https://topiary.tweag.io)


### PR DESCRIPTION
This PR adds support for [Biome](https://biomejs.dev/) to the `javascript`, `javascriptreact`, `typescript`, `typescriptreact`, `json`, and `jsonc` file types.

