### PR TITLE
Fix biome formatter function name in TypeScript

### DIFF
--- a/autoload/neoformat/formatters/typescript.vim
+++ b/autoload/neoformat/formatters/typescript.vim
@@ -78,7 +78,7 @@ function! neoformat#formatters#typescript#denofmt() abort
         \ }
 endfunction
 
-function! neoformat#formatters#javascript#biome() abort
+function! neoformat#formatters#typescript#biome() abort
     return {
         \ 'exe': 'biome',
         \ 'try_node_exe': 1,


### PR DESCRIPTION
Without this, I get this error:

```
Error detected while processing BufReadPost Autocommands for "*":                                                                                                                                                                                                                                                                                                                              
Error executing lua callback: /usr/share/nvim/runtime/filetype.lua:35: Error executing lua: /usr/share/nvim/runtime/filetype.lua:36: BufReadPost Autocommands for "*"..FileType Autocommands for "*"..function <SNR>1_LoadFTPlugin[20]..script /home/benjie/.local/share/nvim/site/pack/packer/start/local-npm-bin.vim/ftplugin/typescript.vim[20]../home/benjie/.local/share/nvim/site/pack/packer/start/neoformat/autoload/neoformat/formatters/typescript.vim, line 89: Vim(function):E746: Function name does not match script file name: neoformat#formatters#javascript#biome                                                                                                                                                                                                           
stack traceback:                                                                                                                                                                                                                                                                                                                                                                               
        [C]: in function 'nvim_cmd'                                                                                                                                                                                                                                                                                                                                                            
        /usr/share/nvim/runtime/filetype.lua:36: in function </usr/share/nvim/runtime/filetype.lua:35>                                                                                                                                                                                                                                                                                         
        [C]: in function 'nvim_buf_call'                                                                                                                                                                                                                                                                                                                                                       
        /usr/share/nvim/runtime/filetype.lua:35: in function </usr/share/nvim/runtime/filetype.lua:10>                                                                                                                                                                                                                                                                                         
stack traceback:                                                                                                                                                                                                                                                                                                                                                                               
        [C]: in function 'nvim_buf_call'                                                                                                                                                                                                                                                                                                                                                       
        /usr/share/nvim/runtime/filetype.lua:35: in function </usr/share/nvim/runtime/filetype.lua:10>  
```

The key part of which I believe to be:

```
neoformat/formatters/typescript.vim, line 89: Vim(function):E746: Function name does not match script file name: neoformat#formatters#javascript#biome     
```

I don't use biome so I've not tested the function still works.