### PR TITLE
Add Typst formatters

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,6 +545,9 @@ that caused Neoformat to be invoked.
     [`clang-format`](http://clang.llvm.org/docs/ClangFormat.html),
     [`deno fmt`](https://deno.land/manual/tools/formatter),
     [`biome format`](https://biomejs.dev)
+- Typst
+  - [`typstfmt`](https://github.com/astrale-sharp/typstfmt)
+    [`typstyle`](https://github.com/Enter-tainer/typstyle)
 - V
   - `v fmt` (ships with [`v`](https://vlang.io))
 - VALA

--- a/autoload/neoformat/formatters/typst.vim
+++ b/autoload/neoformat/formatters/typst.vim
@@ -1,0 +1,17 @@
+function! neoformat#formatters#typst#enabled() abort
+    return ['typst', 'typstyle']
+endfunction
+
+function! neoformat#formatters#typst#typstfmt() abort
+    return {
+        \ 'exe': 'typstfmt',
+        \ 'stdin': 1,
+        \ }
+endfunction
+
+function! neoformat#formatters#typst#typstyle() abort
+    return {
+        \ 'exe': 'typstyle',
+        \ 'stdin': 1,
+        \ }
+endfunction

--- a/doc/neoformat.txt
+++ b/doc/neoformat.txt
@@ -503,6 +503,9 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
     [`clang-format`](http://clang.llvm.org/docs/ClangFormat.html),
     [`deno fmt`](https://deno.land/manual/tools/formatter),
     [`biome`](https://biomejs.dev)
+- Typst
+  - [`typstfmt`](https://github.com/astrale-sharp/typstfmt)
+    [`typstyle`](https://github.com/Enter-tainer/typstyle)
 - Toml
   - [`taplo`](https://taplo.tamasfe.dev/cli/usage/formatting.html),
     [`topiary`](https://topiary.tweag.io)


### PR DESCRIPTION
I added two formatters for Typst, `typstfmt` and `typstyle`. I also updated `README.md` and `doc/neoformat.txt`.