### PR TITLE
Give cabal-fmt access to the filename

### DIFF
--- a/autoload/neoformat/formatters/cabal.vim
+++ b/autoload/neoformat/formatters/cabal.vim
@@ -4,7 +4,9 @@ endfunction
 
 function! neoformat#formatters#cabal#cabalfmt() abort
     return {
+        \ 'args' : [expand('%:p')],
         \ 'exe' : 'cabal-fmt',
-        \ 'stdin' : 1,
+        \ 'no_append' : 1,
+        \ 'stdin' : 0
         \ }
 endfunction


### PR DESCRIPTION
`cabal-fmt` supports pragmas, all of which are [currently undocumented](https://github.com/phadej/cabal-fmt/issues/35), some of which (e.g. `expand`) only work when given the original file path.

This PR makes `cabal-fmt` run on the original file instead of a temporary one.
