### PR TITLE
Add support for eruby.

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,8 @@ that caused Neoformat to be invoked.
   - [`mix format`](https://hexdocs.pm/mix/master/Mix.Tasks.Format.html)
 - Elm
   - [`elm-format`](https://github.com/avh4/elm-format)
+- Eruby
+  - [`htmlbeautifier`](https://github.com/threedaymonk/htmlbeautifier)
 - Erlang
   - [`erlfmt`](https://github.com/WhatsApp/erlfmt)
 - Fennel

--- a/autoload/neoformat/formatters/eruby.vim
+++ b/autoload/neoformat/formatters/eruby.vim
@@ -1,0 +1,11 @@
+function! neoformat#formatters#eruby#enabled() abort
+    return ['htmlbeautifier']
+endfunction
+
+function! neoformat#formatters#eruby#htmlbeautifier() abort
+    return {
+        \ 'exe': 'htmlbeautifier',
+        \ 'args': ['--keep-blank-lines', '1'],
+        \ 'stdin': 1
+        \ }
+endfunction

--- a/doc/neoformat.txt
+++ b/doc/neoformat.txt
@@ -274,6 +274,8 @@ SUPPORTED FILETYPES				*neoformat-supported-filetypes*
   - [mix format](https://hexdocs.pm/mix/master/Mix.Tasks.Format.html)
 - Elm
   - [`elm-format`](https://github.com/avh4/elm-format)
+- Eruby
+  - [`htmlbeautifier`](https://github.com/threedaymonk/htmlbeautifier)
 - Erlang
   - [`erlfmt`](https://github.com/WhatsApp/erlfmt)
 - Fish


### PR DESCRIPTION
HTMLBeautifier (https://github.com/threedaymonk/htmlbeautifier) can format eruby files (.html.erb). 

The code is copied from here: https://github.com/sbdchd/neoformat/issues/255 .

I've tested it from my Mac.

For new users who just arrived at this repo: you need to install htmlbeautifier program first (`gem install htmlbeautifier`), and then run :Neoformat in vim.