### PR TITLE
Add the required `--stdin-input-file` flag to ormolu

### DIFF
--- a/autoload/neoformat/formatters/haskell.vim
+++ b/autoload/neoformat/formatters/haskell.vim
@@ -55,7 +55,7 @@ function! neoformat#formatters#haskell#ormolu() abort
     endif
     return {
         \ 'exe' : 'ormolu',
-        \ 'args': [opts],
+        \ 'args': ['--stdin-input-file', '%:p', opts],
         \ 'stdin' : 1,
         \ }
 endfunction


### PR DESCRIPTION
Ormolu requires this flag since version 0.5.0.0 (released on 2022-05-12) to identify the associated cabal file.