### PR TITLE
`typstfmt` successfully works now

### DIFF
--- a/autoload/neoformat/formatters/typst.vim
+++ b/autoload/neoformat/formatters/typst.vim
@@ -1,5 +1,5 @@
 function! neoformat#formatters#typst#enabled() abort
-    return ['typst', 'typstyle']
+    return ['typstfmt', 'typstyle']
 endfunction
 
 function! neoformat#formatters#typst#typstfmt() abort


### PR DESCRIPTION
Fixed an issue where `typst` would be seen as formatter instead of `typstfmt`.