### PR TITLE
fix: add 'format' param required for csharpier v1.x

### DIFF
--- a/autoload/neoformat/formatters/cs.vim
+++ b/autoload/neoformat/formatters/cs.vim
@@ -29,7 +29,7 @@ endfunction
 function! neoformat#formatters#cs#csharpier() abort
     return {
         \ 'exe': 'dotnet',
-        \ 'args': ['csharpier'],
+        \ 'args': ['csharpier', 'format'],
         \ 'stdin': 1,
         \ }
 endfunction


### PR DESCRIPTION
Adds the 'format' parameter required for csharpier v1.x

Is a fix for this issue:
https://github.com/sbdchd/neoformat/issues/506