### PR TITLE
Invoke bean-format with '-' to be compatible with Beancount 2 and 3

### DIFF
--- a/autoload/neoformat/formatters/beancount.vim
+++ b/autoload/neoformat/formatters/beancount.vim
@@ -5,6 +5,7 @@ endfunction
 function! neoformat#formatters#beancount#beanformat() abort
     return {
         \ 'exe': 'bean-format',
+        \ 'args': ['-'],
         \ 'stdin': 1,
         \ }
 endfunction


### PR DESCRIPTION
Beancount's `bean-format` requires a filename as argument in version 3. Pass `-` to read from stdin, which happens to be compatible with `bean-format` for Beancount 2.