### PR TITLE
fix: call csharpier directly

### DIFF
--- a/autoload/neoformat/formatters/cs.vim
+++ b/autoload/neoformat/formatters/cs.vim
@@ -28,8 +28,8 @@ endfunction
 
 function! neoformat#formatters#cs#csharpier() abort
     return {
-        \ 'exe': 'dotnet',
-        \ 'args': ['csharpier', 'format'],
+        \ 'exe': 'csharpier',
+        \ 'args': ['format'],
         \ 'stdin': 1,
         \ }
 endfunction


### PR DESCRIPTION
This pull request fixes an error

```
Neoformat: formatters dotnet failed to run
```

Csharpier version `>=1` does not allow being call like `dotnet csharpier ...` as far as I understand. I tested it on both Linux and macOS.