### PR TITLE
Fix typo in css.vim

### DIFF
--- a/autoload/neoformat/formatters/css.vim
+++ b/autoload/neoformat/formatters/css.vim
@@ -65,7 +65,7 @@ function! neoformat#formatters#css#stylelint() abort
             \ }
 endfunction
 
-function! neoformat#formatters#json#topiary() abort
+function! neoformat#formatters#css#topiary() abort
     return {
         \ 'exe': 'topiary',
         \ 'no_append': 1,


### PR DESCRIPTION
I'm getting an error on startup about this mismatch