### PR TITLE
Add prettierd to astro's formatters

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,8 @@ that caused Neoformat to be invoked.
 - Assembly
   - [`asmfmt`](https://github.com/klauspost/asmfmt)
 - Astro
-  - [`prettier`](https://github.com/withastro/prettier-plugin-astro/)
+  - [`prettier`](https://github.com/withastro/prettier-plugin-astro/),
+    [`prettierd`](https://github.com/fsouza/prettierd)
 - Bazel
   - [`buildifier`](https://github.com/bazelbuild/buildtools/blob/master/buildifier/README.md)
 - Beancount

--- a/autoload/neoformat/formatters/astro.vim
+++ b/autoload/neoformat/formatters/astro.vim
@@ -10,3 +10,11 @@ function! neoformat#formatters#astro#prettier() abort
         \ 'try_node_exe': 1,
         \ }
 endfunction
+
+function! neoformat#formatters#astro#prettierd() abort
+    return {
+        \ 'exe': 'prettierd',
+        \ 'args': ['"%:p"'],
+        \ 'stdin': 1,
+        \ }
+endfunction

--- a/autoload/neoformat/formatters/astro.vim
+++ b/autoload/neoformat/formatters/astro.vim
@@ -1,5 +1,5 @@
 function! neoformat#formatters#astro#enabled() abort
-    return ['prettier']
+    return ['prettier, prettierd']
 endfunction
 
 function! neoformat#formatters#astro#prettier() abort


### PR DESCRIPTION
I noticed that astro has prettier support, but not <code><a href="https://github.com/fsouza/prettierd">prettierd</a></code>. So this PR just adds this short snippet to fill in on that. Most of the other languages formatted with prettier have prettierd support, so I feel there's no reason for Astro to not get the same treatment.

```vim
function! neoformat#formatters#astro#prettierd() abort
    return {
        \ 'exe': 'prettierd',
        \ 'args': ['"%:p"'],
        \ 'stdin': 1,
        \ }
endfunction
```